### PR TITLE
feat: Add Telegram tool for messaging

### DIFF
--- a/tools/telegram/README.md
+++ b/tools/telegram/README.md
@@ -1,0 +1,279 @@
+# Telegram Tool
+
+Send messages, photos, documents, and more to Telegram users and groups from Beige agents.
+
+## Features
+
+- **Text messages** - Send formatted text with Markdown or HTML
+- **Photos** - Send images by URL or file_id
+- **Documents** - Send files by URL or file_id
+- **Thread support** - Post to specific topics in supergroups
+- **Reply-to** - Reply to specific messages
+- **Silent mode** - Send without notification
+- **Link preview control** - Disable web page previews
+- **Chat filtering** - Allow/deny list for security
+- **Bot info** - Get bot details and chat information
+
+## Installation
+
+Install this tool individually:
+
+```bash
+beige tools install github:matthias-hausberger/beige-toolkit/tools/telegram
+```
+
+Or install all tools from the toolkit:
+
+```bash
+# From npm
+beige tools install npm:@matthias-hausberger/beige-toolkit
+
+# From GitHub
+beige tools install github:matthias-hausberger/beige-toolkit
+```
+
+## Configuration
+
+Add to your agent's config:
+
+```json5
+{
+  tools: {
+    telegram: {
+      config: {
+        botToken: "1234567890:ABCdefGHIjklMNOpqrsTUVwxyz",
+        defaultChatId: "58687206",
+        defaultParseMode: "MarkdownV2",
+        allowChats: ["58687206", "-1001234567890"],
+      },
+    },
+  },
+}
+```
+
+### Config Options
+
+| Option | Type | Required | Description |
+|--------|------|----------|-------------|
+| `botToken` | string | **Yes** | Telegram Bot API token from @BotFather |
+| `defaultChatId` | string \| number | No | Default chat/user ID to send to |
+| `defaultParseMode` | string | No | Default formatting: `MarkdownV2`, `Markdown`, `HTML` |
+| `allowChats` | array | No | Whitelist of allowed chat IDs |
+| `denyChats` | array | No | Blacklist of blocked chat IDs (deny beats allow) |
+| `timeout` | number | No | Request timeout in seconds (default: 30) |
+
+### Getting Your Bot Token
+
+1. Open Telegram and search for [@BotFather](https://t.me/botfather)
+2. Send `/newbot` and follow the instructions
+3. Copy the token provided (format: `1234567890:ABCdef...`)
+
+### Getting Chat IDs
+
+For **private chats**, your user ID is shown by bots like [@userinfobot](https://t.me/userinfobot).
+
+For **groups/supergroups**, add the bot to the group and use:
+```
+telegram updates --limit 10
+```
+Look for the `chat.id` in the response.
+
+## Commands
+
+### Send a Text Message
+
+```bash
+# Basic message
+telegram send --chat 58687206 --text "Hello from beige!"
+
+# With default chat configured
+telegram send --text "Hello!"
+
+# Markdown formatting
+telegram send --chat 58687206 --text "*Bold* and _italic_" --parse-mode Markdown
+
+# Reply to a message
+telegram send --chat 58687206 --text "Reply!" --reply-to 12345
+
+# Post to a thread/topic (supergroups)
+telegram send --chat -1001234567890 --text "Topic message" --thread 42
+
+# Silent (no notification)
+telegram send --chat 58687206 --text "Quiet message" --silent
+
+# Disable link previews
+telegram send --chat 58687206 --text "Check https://example.com" --disable-preview
+```
+
+### Send a Photo
+
+```bash
+# By URL
+telegram photo --chat 58687206 --photo https://example.com/image.jpg
+
+# With caption
+telegram photo --chat 58687206 --photo https://example.com/image.jpg --caption "Check this out!"
+
+# Reply to message
+telegram photo --chat 58687206 --photo https://example.com/image.jpg --reply-to 12345
+
+# Post to thread
+telegram photo --chat -1001234567890 --photo https://example.com/image.jpg --thread 42
+```
+
+### Send a Document
+
+```bash
+# By URL
+telegram document --chat 58687206 --document https://example.com/file.pdf
+
+# With caption
+telegram document --chat 58687206 --document https://example.com/report.pdf --caption "Monthly report"
+
+# Post to thread
+telegram document --chat -1001234567890 --document https://example.com/file.pdf --thread 42
+```
+
+### Get Bot Info
+
+```bash
+telegram me
+```
+
+Returns:
+```json
+{
+  "id": 1234567890,
+  "is_bot": true,
+  "first_name": "Beige Bot",
+  "username": "beige_bot",
+  "can_join_groups": true,
+  "can_read_all_group_messages": false
+}
+```
+
+### Get Chat Info
+
+```bash
+telegram chat --chat 58687206
+```
+
+Returns chat details including type, title (for groups), username, etc.
+
+### Get Updates
+
+```bash
+# Get recent updates
+telegram updates
+
+# Limit number of updates
+telegram updates --limit 10
+
+# Get updates starting from a specific offset
+telegram updates --offset 100
+```
+
+## Thread/Topic Support
+
+For supergroups with [Topics](https://telegram.org/blog/topics-in-groups) enabled:
+
+```bash
+# Post to a specific topic
+telegram send --chat -1001234567890 --text "Topic message" --thread 42
+```
+
+The `--thread` flag sets `message_thread_id` in the API call.
+
+## Formatting
+
+### MarkdownV2 (recommended)
+
+```bash
+telegram send --chat 58687206 --text "*bold* _italic_ \`code\`" --parse-mode MarkdownV2
+```
+
+Note: MarkdownV2 requires escaping certain characters. See [Telegram API docs](https://core.telegram.org/bots/api#markdownv2-style).
+
+### Markdown
+
+```bash
+telegram send --chat 58687206 --text "*bold* _italic_ [link](https://example.com)" --parse-mode Markdown
+```
+
+### HTML
+
+```bash
+telegram send --chat 58687206 --text "<b>bold</b> <i>italic</i> <a href='https://example.com'>link</a>" --parse-mode HTML
+```
+
+## Security
+
+### Chat Filtering
+
+Control which chats the bot can message:
+
+```json5
+// Only allow specific chats
+config: {
+  allowChats: ["58687206", "-1001234567890"],
+}
+
+// Block specific chats
+config: {
+  denyChats: ["-1009999999999"],
+}
+
+// Combine: allow all except blocked
+config: {
+  denyChats: ["-1009999999999"],
+}
+```
+
+**Precedence:** `denyChats` takes priority over `allowChats`.
+
+### Best Practices
+
+1. **Store bot token securely** - Use environment variables or secret management
+2. **Use allowChats** - Restrict which chats can receive messages
+3. **Validate user input** - Be careful with user-provided message content
+4. **Handle rate limits** - Telegram has rate limits; implement backoff if needed
+
+## Use Cases
+
+- **Notifications** - Alert users about events, deploys, errors
+- **Cron job alerts** - Send scheduled status updates
+- **Interactive bots** - Respond to user commands
+- **Report delivery** - Send daily/weekly reports
+- **Monitoring alerts** - Alert on system issues
+- **CI/CD notifications** - Notify on build status
+
+## Error Handling
+
+The tool returns clear error messages:
+
+```
+Error: No chat ID specified. Use --chat or configure defaultChatId.
+```
+
+```
+Telegram API error: Bad Request: chat not found (code 400)
+```
+
+```
+Permission denied: Chat -1001234567890 is in deny list
+```
+
+## API Reference
+
+This tool uses the [Telegram Bot API](https://core.telegram.org/bots/api). Supported methods:
+
+- `sendMessage` - Send text messages
+- `sendPhoto` - Send photos
+- `sendDocument` - Send documents
+- `getMe` - Get bot info
+- `getChat` - Get chat info
+- `getUpdates` - Get pending updates
+
+## License
+
+MIT

--- a/tools/telegram/SKILL.md
+++ b/tools/telegram/SKILL.md
@@ -1,0 +1,161 @@
+# Telegram Tool — Usage Guide
+
+Send messages, photos, and documents to Telegram users and groups via the Bot API.
+
+## Calling Convention
+
+```sh
+/tools/bin/telegram <subcommand> [options]
+```
+
+## Quick Examples
+
+### Send a Message
+
+```sh
+# Send to specific user
+/tools/bin/telegram send --chat 58687206 --text "Hello from beige!"
+
+# With default chat configured, just:
+/tools/bin/telegram send --text "Hello!"
+
+# Formatted message
+/tools/bin/telegram send --chat 58687206 --text "*Bold* _italic_" --parse-mode Markdown
+```
+
+### Send Media
+
+```sh
+# Photo by URL
+/tools/bin/telegram photo --chat 58687206 --photo https://example.com/image.jpg
+
+# Photo with caption
+/tools/bin/telegram photo --chat 58687206 --photo https://example.com/image.jpg --caption "Check this out!"
+
+# Document
+/tools/bin/telegram document --chat 58687206 --document https://example.com/report.pdf
+```
+
+### Threads and Replies
+
+```sh
+# Post to a topic/thread in a supergroup
+/tools/bin/telegram send --chat -1001234567890 --text "Topic post" --thread 42
+
+# Reply to a specific message
+/tools/bin/telegram send --chat 58687206 --text "Reply!" --reply-to 12345
+```
+
+### Get Info
+
+```sh
+# Get bot info
+/tools/bin/telegram me
+
+# Get chat info
+/tools/bin/telegram chat --chat 58687206
+
+# Get pending updates
+/tools/bin/telegram updates --limit 10
+```
+
+## Subcommands
+
+| Subcommand | Aliases | Description |
+|------------|---------|-------------|
+| `send` | `message`, `msg` | Send a text message |
+| `photo` | `image`, `img` | Send a photo |
+| `document` | `doc`, `file` | Send a document |
+| `me` | `bot`, `self` | Get bot information |
+| `chat` | `info` | Get chat information |
+| `updates` | `poll` | Get pending updates |
+
+## Options
+
+### Send Options
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `--chat` | number | Chat/user ID (required unless defaultChatId configured) |
+| `--text` | string | Message text to send |
+| `--thread` | number | Thread/topic ID for supergroups |
+| `--reply-to` | number | Message ID to reply to |
+| `--parse-mode` | string | Formatting: `Markdown`, `MarkdownV2`, or `HTML` |
+| `--silent` | flag | Send without notification sound |
+| `--disable-preview` | flag | Disable web page preview for links |
+
+### Photo Options
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `--chat` | number | Chat/user ID |
+| `--photo` | string | Photo URL or file_id |
+| `--caption` | string | Photo caption |
+| `--thread` | number | Thread/topic ID |
+| `--reply-to` | number | Message ID to reply to |
+
+### Document Options
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `--chat` | number | Chat/user ID |
+| `--document` | string | Document URL or file_id |
+| `--caption` | string | Document caption |
+| `--thread` | number | Thread/topic ID |
+| `--reply-to` | number | Message ID to reply to |
+
+### Updates Options
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `--limit` | number | Maximum number of updates to retrieve |
+| `--offset` | number | Identifier of first update to return |
+
+## Formatting
+
+### Markdown
+
+```sh
+/tools/bin/telegram send --chat 58687206 --text "*bold* _italic_ [link](https://example.com)" --parse-mode Markdown
+```
+
+### HTML
+
+```sh
+/tools/bin/telegram send --chat 58687206 --text "<b>bold</b> <i>italic</i> <a href='https://example.com'>link</a>" --parse-mode HTML
+```
+
+### MarkdownV2
+
+Note: Requires escaping special characters.
+
+```sh
+/tools/bin/telegram send --chat 58687206 --text "*bold* _italic_ \`code\`" --parse-mode MarkdownV2
+```
+
+## Thread/Topic Support
+
+For supergroups with Topics enabled, use `--thread` to post to a specific topic:
+
+```sh
+/tools/bin/telegram send --chat -1001234567890 --text "Topic message" --thread 42
+```
+
+## Error Messages
+
+| Error | Cause |
+|-------|-------|
+| `No chat ID specified` | Missing `--chat` and no `defaultChatId` configured |
+| `No message text specified` | Missing `--text` for send command |
+| `botToken not configured` | Tool missing required `botToken` config |
+| `Permission denied: Chat X is in deny list` | Chat ID blocked by `denyChats` |
+| `Permission denied: Chat X is not in allow list` | Chat ID not in `allowChats` whitelist |
+| `Telegram API error: Bad Request: chat not found` | Invalid chat ID or bot not in chat |
+
+## Tips
+
+- Configure `defaultChatId` for your primary contact to simplify commands
+- Use `--silent` for non-urgent notifications
+- Use `--parse-mode Markdown` for simple formatting
+- Call `telegram updates` to discover chat IDs after adding bot to groups
+- Use `allowChats` to restrict which chats the bot can message

--- a/tools/telegram/__tests__/unit.test.ts
+++ b/tools/telegram/__tests__/unit.test.ts
@@ -1,0 +1,747 @@
+/**
+ * Unit tests for the Telegram tool handler.
+ *
+ * Tests use mocked curl execution — no real HTTP requests are made.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  createHandler,
+  parseArgs,
+  isChatAllowed,
+  apiUrl,
+} from "../index.js";
+
+// ---------------------------------------------------------------------------
+// Mock curl executor
+// ---------------------------------------------------------------------------
+
+interface MockCall {
+  args: string[];
+  timestamp: number;
+}
+
+let mockCalls: MockCall[] = [];
+let mockResponse: { stdout: string; stderr: string; exitCode: number } = {
+  stdout: "",
+  stderr: "",
+  exitCode: 0,
+};
+
+// Mock spawn to capture curl calls
+vi.mock("child_process", () => ({
+  spawn: vi.fn(() => {
+    const call = {
+      args: vi.mocked.lastCall()?.[1] as string[],
+      timestamp: Date.now(),
+    };
+    mockCalls.push(call);
+
+    return {
+      stdout: {
+        on: (_event: string, cb: (data: Buffer) => void) => {
+          if (mockResponse.stdout) {
+            cb(Buffer.from(mockResponse.stdout));
+          }
+        },
+      },
+      stderr: {
+        on: (_event: string, cb: (data: Buffer) => void) => {
+          if (mockResponse.stderr) {
+            cb(Buffer.from(mockResponse.stderr));
+          }
+        },
+      },
+      on: (_event: string, cb: (code: number) => void) => {
+        setTimeout(() => cb(mockResponse.exitCode), 0);
+      },
+      kill: vi.fn(),
+    };
+  }),
+}));
+
+function resetMock() {
+  mockCalls = [];
+  mockResponse = { stdout: "", stderr: "", exitCode: 0 };
+}
+
+// ---------------------------------------------------------------------------
+// parseArgs tests
+// ---------------------------------------------------------------------------
+
+describe("parseArgs", () => {
+  it("parses empty args", () => {
+    const result = parseArgs([]);
+    expect(result.subcommand).toBe("");
+    expect(result.args).toEqual({});
+  });
+
+  it("extracts subcommand", () => {
+    const result = parseArgs(["send"]);
+    expect(result.subcommand).toBe("send");
+  });
+
+  it("parses --key value", () => {
+    const result = parseArgs(["send", "--chat", "12345", "--text", "hello"]);
+    expect(result.args.chat).toBe(12345);
+    expect(result.args.text).toBe("hello");
+  });
+
+  it("parses --key=value", () => {
+    const result = parseArgs(["send", "--chat=12345", "--text=hello"]);
+    expect(result.args.chat).toBe(12345);
+    expect(result.args.text).toBe("hello");
+  });
+
+  it("parses boolean flags", () => {
+    const result = parseArgs(["send", "--silent"]);
+    expect(result.args.silent).toBe(true);
+  });
+
+  it("parses numeric values", () => {
+    const result = parseArgs(["send", "--chat", "58687206", "--reply-to", "123"]);
+    expect(result.args.chat).toBe(58687206);
+    expect(result.args["reply-to"]).toBe(123);
+  });
+
+  it("preserves string values for non-numeric", () => {
+    const result = parseArgs(["send", "--text", "Hello world!", "--parse-mode", "Markdown"]);
+    expect(result.args.text).toBe("Hello world!");
+    expect(result.args["parse-mode"]).toBe("Markdown");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isChatAllowed tests
+// ---------------------------------------------------------------------------
+
+describe("isChatAllowed", () => {
+  it("allows any chat when no restrictions configured", () => {
+    expect(isChatAllowed("58687206", {}).allowed).toBe(true);
+    expect(isChatAllowed(-1001234567890, {}).allowed).toBe(true);
+  });
+
+  it("blocks chats in deny list", () => {
+    const config = { denyChats: ["58687206", -1009999999999] };
+    expect(isChatAllowed("58687206", config).allowed).toBe(false);
+    expect(isChatAllowed(58687206, config).allowed).toBe(false);
+    expect(isChatAllowed(-1009999999999, config).allowed).toBe(false);
+    expect(isChatAllowed("12345678", config).allowed).toBe(true);
+  });
+
+  it("allows only chats in allow list", () => {
+    const config = { allowChats: ["58687206", -1001234567890] };
+    expect(isChatAllowed("58687206", config).allowed).toBe(true);
+    expect(isChatAllowed(58687206, config).allowed).toBe(true);
+    expect(isChatAllowed("12345678", config).allowed).toBe(false);
+  });
+
+  it("deny beats allow", () => {
+    const config = {
+      allowChats: ["58687206"],
+      denyChats: ["58687206"],
+    };
+    expect(isChatAllowed("58687206", config).allowed).toBe(false);
+  });
+
+  it("normalizes chat IDs as strings", () => {
+    const config = { denyChats: [58687206] };
+    // String form should also be blocked
+    expect(isChatAllowed("58687206", config).allowed).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// apiUrl tests
+// ---------------------------------------------------------------------------
+
+describe("apiUrl", () => {
+  it("builds correct API URL", () => {
+    const token = "1234567890:ABCdef";
+    expect(apiUrl(token, "sendMessage")).toBe(
+      "https://api.telegram.org/bot1234567890:ABCdef/sendMessage"
+    );
+    expect(apiUrl(token, "getMe")).toBe(
+      "https://api.telegram.org/bot1234567890:ABCdef/getMe"
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Handler tests
+// ---------------------------------------------------------------------------
+
+describe("handler", () => {
+  beforeEach(() => {
+    resetMock();
+  });
+
+  const defaultConfig = {
+    botToken: "test-token-12345",
+    defaultChatId: "58687206",
+  };
+
+  it("returns usage when called with no args", async () => {
+    const handler = createHandler(defaultConfig);
+    const result = await handler([]);
+    expect(result.exitCode).toBe(1);
+    expect(result.output).toContain("Usage:");
+    expect(result.output).toContain("telegram");
+  });
+
+  it("returns usage for help subcommand", async () => {
+    const handler = createHandler(defaultConfig);
+    const result = await handler(["help"]);
+    expect(result.exitCode).toBe(0);
+    expect(result.output).toContain("telegram");
+  });
+
+  it("rejects unknown subcommand", async () => {
+    const handler = createHandler(defaultConfig);
+    const result = await handler(["unknown"]);
+    expect(result.exitCode).toBe(1);
+    expect(result.output).toContain("Unknown subcommand");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// send message tests
+// ---------------------------------------------------------------------------
+
+describe("handler - send", () => {
+  beforeEach(() => {
+    resetMock();
+  });
+
+  const config = {
+    botToken: "test-token-12345",
+    defaultChatId: "58687206",
+  };
+
+  it("sends basic message", async () => {
+    mockResponse = {
+      stdout: JSON.stringify({ ok: true, result: { message_id: 1 } }),
+      stderr: "",
+      exitCode: 0,
+    };
+
+    const handler = createHandler(config);
+    const result = await handler(["send", "--chat", "58687206", "--text", "Hello!"]);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.output).toContain("Message sent successfully");
+
+    // Check curl was called correctly
+    expect(mockCalls.length).toBe(1);
+    const curlArgs = mockCalls[0].args;
+    expect(curlArgs).toContain("-X");
+    expect(curlArgs).toContain("POST");
+    expect(curlArgs).toContain("Content-Type: application/json");
+  });
+
+  it("uses defaultChatId when --chat not specified", async () => {
+    mockResponse = {
+      stdout: JSON.stringify({ ok: true, result: { message_id: 1 } }),
+      stderr: "",
+      exitCode: 0,
+    };
+
+    const handler = createHandler(config);
+    const result = await handler(["send", "--text", "Hello!"]);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.output).toContain("58687206");
+  });
+
+  it("errors when no chat ID available", async () => {
+    const handler = createHandler({ botToken: "test-token" });
+    const result = await handler(["send", "--text", "Hello!"]);
+
+    expect(result.exitCode).toBe(1);
+    expect(result.output).toContain("No chat ID specified");
+    expect(mockCalls.length).toBe(0);
+  });
+
+  it("errors when no text provided", async () => {
+    const handler = createHandler(config);
+    const result = await handler(["send", "--chat", "58687206"]);
+
+    expect(result.exitCode).toBe(1);
+    expect(result.output).toContain("No message text specified");
+    expect(mockCalls.length).toBe(0);
+  });
+
+  it("errors when botToken not configured", async () => {
+    const handler = createHandler({});
+    const result = await handler(["send", "--chat", "58687206", "--text", "Hi"]);
+
+    expect(result.exitCode).toBe(1);
+    expect(result.output).toContain("botToken not configured");
+    expect(mockCalls.length).toBe(0);
+  });
+
+  it("blocks message to denied chat", async () => {
+    const handler = createHandler({
+      ...config,
+      denyChats: ["58687206"],
+    });
+    const result = await handler(["send", "--chat", "58687206", "--text", "Hi"]);
+
+    expect(result.exitCode).toBe(1);
+    expect(result.output).toContain("Permission denied");
+    expect(result.output).toContain("deny list");
+    expect(mockCalls.length).toBe(0);
+  });
+
+  it("blocks message to non-allowed chat", async () => {
+    const handler = createHandler({
+      ...config,
+      allowChats: ["12345678"],
+    });
+    const result = await handler(["send", "--chat", "58687206", "--text", "Hi"]);
+
+    expect(result.exitCode).toBe(1);
+    expect(result.output).toContain("Permission denied");
+    expect(result.output).toContain("not in allow list");
+    expect(mockCalls.length).toBe(0);
+  });
+
+  it("handles Telegram API error", async () => {
+    mockResponse = {
+      stdout: JSON.stringify({
+        ok: false,
+        error_code: 400,
+        description: "Bad Request: chat not found",
+      }),
+      stderr: "",
+      exitCode: 0,
+    };
+
+    const handler = createHandler(config);
+    const result = await handler(["send", "--chat", "58687206", "--text", "Hi"]);
+
+    expect(result.exitCode).toBe(1);
+    expect(result.output).toContain("Telegram API error");
+    expect(result.output).toContain("chat not found");
+  });
+
+  it("includes thread ID in request", async () => {
+    mockResponse = {
+      stdout: JSON.stringify({ ok: true, result: { message_id: 1 } }),
+      stderr: "",
+      exitCode: 0,
+    };
+
+    const handler = createHandler(config);
+    await handler(["send", "--chat", "-1001234567890", "--text", "Topic!", "--thread", "42"]);
+
+    expect(mockCalls.length).toBe(1);
+    const curlArgs = mockCalls[0].args;
+    const jsonPayload = curlArgs[curlArgs.indexOf("-d") + 1];
+    const payload = JSON.parse(jsonPayload);
+    expect(payload.message_thread_id).toBe(42);
+  });
+
+  it("includes reply_to_message_id in request", async () => {
+    mockResponse = {
+      stdout: JSON.stringify({ ok: true, result: { message_id: 2 } }),
+      stderr: "",
+      exitCode: 0,
+    };
+
+    const handler = createHandler(config);
+    await handler(["send", "--chat", "58687206", "--text", "Reply!", "--reply-to", "123"]);
+
+    expect(mockCalls.length).toBe(1);
+    const curlArgs = mockCalls[0].args;
+    const jsonPayload = curlArgs[curlArgs.indexOf("-d") + 1];
+    const payload = JSON.parse(jsonPayload);
+    expect(payload.reply_to_message_id).toBe(123);
+  });
+
+  it("includes parse_mode in request", async () => {
+    mockResponse = {
+      stdout: JSON.stringify({ ok: true, result: { message_id: 1 } }),
+      stderr: "",
+      exitCode: 0,
+    };
+
+    const handler = createHandler(config);
+    await handler(["send", "--chat", "58687206", "--text", "*bold*", "--parse-mode", "Markdown"]);
+
+    expect(mockCalls.length).toBe(1);
+    const curlArgs = mockCalls[0].args;
+    const jsonPayload = curlArgs[curlArgs.indexOf("-d") + 1];
+    const payload = JSON.parse(jsonPayload);
+    expect(payload.parse_mode).toBe("Markdown");
+  });
+
+  it("includes thread id when --thread", async () => {
+    mockResponse = {
+      stdout: JSON.stringify({ ok: true, result: { message_id: 1 } }),
+      stderr: "",
+      exitCode: 0,
+    };
+
+    const handler = createHandler(config);
+    await handler(["send", "--chat", "58687206", "--text", "Topic!", "--thread", "42"]);
+
+    expect(mockCalls.length).toBe(1);
+    const curlArgs = mockCalls[0].args;
+    const jsonPayload = curlArgs[curlArgs.indexOf("-d") + 1];
+    const payload = JSON.parse(jsonPayload);
+    expect(payload.message_thread_id).toBe(42);
+  });
+
+  it("includes disable_notification when --silent", async () => {
+    mockResponse = {
+      stdout: JSON.stringify({ ok: true, result: { message_id: 1 } }),
+      stderr: "",
+      exitCode: 0,
+    };
+
+    const handler = createHandler(config);
+    await handler(["send", "--chat", "58687206", "--text", "Quiet!", "--silent"]);
+
+    expect(mockCalls.length).toBe(1);
+    const curlArgs = mockCalls[0].args;
+    const jsonPayload = curlArgs[curlArgs.indexOf("-d") + 1];
+    const payload = JSON.parse(jsonPayload);
+    expect(payload.disable_notification).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// photo tests
+// ---------------------------------------------------------------------------
+
+describe("handler - photo", () => {
+  beforeEach(() => {
+    resetMock();
+  });
+
+  const config = {
+    botToken: "test-token-12345",
+    defaultChatId: "58687206",
+  };
+
+  it("sends photo", async () => {
+    mockResponse = {
+      stdout: JSON.stringify({ ok: true, result: { message_id: 1 } }),
+      stderr: "",
+      exitCode: 0,
+    };
+
+    const handler = createHandler(config);
+    const result = await handler([
+      "photo",
+      "--chat", "58687206",
+      "--photo", "https://example.com/image.jpg",
+    ]);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.output).toContain("Photo sent successfully");
+
+    const curlArgs = mockCalls[0].args;
+    const jsonPayload = curlArgs[curlArgs.indexOf("-d") + 1];
+    const payload = JSON.parse(jsonPayload);
+    expect(payload.photo).toBe("https://example.com/image.jpg");
+  });
+
+  it("includes caption", async () => {
+    mockResponse = {
+      stdout: JSON.stringify({ ok: true, result: { message_id: 1 } }),
+      stderr: "",
+      exitCode: 0,
+    };
+
+    const handler = createHandler(config);
+    await handler([
+      "photo",
+      "--chat", "58687206",
+      "--photo", "https://example.com/image.jpg",
+      "--caption", "Check this out!",
+    ]);
+
+    const curlArgs = mockCalls[0].args;
+    const jsonPayload = curlArgs[curlArgs.indexOf("-d") + 1];
+    const payload = JSON.parse(jsonPayload);
+    expect(payload.caption).toBe("Check this out!");
+  });
+
+  it("errors when no photo specified", async () => {
+    const handler = createHandler(config);
+    const result = await handler(["photo", "--chat", "58687206"]);
+
+    expect(result.exitCode).toBe(1);
+    expect(result.output).toContain("No photo specified");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// document tests
+// ---------------------------------------------------------------------------
+
+describe("handler - document", () => {
+  beforeEach(() => {
+    resetMock();
+  });
+
+  const config = {
+    botToken: "test-token-12345",
+    defaultChatId: "58687206",
+  };
+
+  it("sends document", async () => {
+    mockResponse = {
+      stdout: JSON.stringify({ ok: true, result: { message_id: 1 } }),
+      stderr: "",
+      exitCode: 0,
+    };
+
+    const handler = createHandler(config);
+    const result = await handler([
+      "document",
+      "--chat", "58687206",
+      "--document", "https://example.com/report.pdf",
+    ]);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.output).toContain("Document sent successfully");
+
+    const curlArgs = mockCalls[0].args;
+    const jsonPayload = curlArgs[curlArgs.indexOf("-d") + 1];
+    const payload = JSON.parse(jsonPayload);
+    expect(payload.document).toBe("https://example.com/report.pdf");
+  });
+
+  it("errors when no document specified", async () => {
+    const handler = createHandler(config);
+    const result = await handler(["document", "--chat", "58687206"]);
+
+    expect(result.exitCode).toBe(1);
+    expect(result.output).toContain("No document specified");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// me (getMe) tests
+// ---------------------------------------------------------------------------
+
+describe("handler - me", () => {
+  beforeEach(() => {
+    resetMock();
+  });
+
+  const config = {
+    botToken: "test-token-12345",
+  };
+
+  it("returns bot info", async () => {
+    mockResponse = {
+      stdout: JSON.stringify({
+        ok: true,
+        result: {
+          id: 1234567890,
+          is_bot: true,
+          first_name: "Test Bot",
+          username: "test_bot",
+        },
+      }),
+      stderr: "",
+      exitCode: 0,
+    };
+
+    const handler = createHandler(config);
+    const result = await handler(["me"]);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.output).toContain("Test Bot");
+    expect(result.output).toContain("test_bot");
+  });
+
+  it("errors when botToken not configured", async () => {
+    const handler = createHandler({});
+    const result = await handler(["me"]);
+
+    expect(result.exitCode).toBe(1);
+    expect(result.output).toContain("botToken not configured");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// chat (getChat) tests
+// ---------------------------------------------------------------------------
+
+describe("handler - chat", () => {
+  beforeEach(() => {
+    resetMock();
+  });
+
+  const config = {
+    botToken: "test-token-12345",
+    defaultChatId: "58687206",
+  };
+
+  it("returns chat info", async () => {
+    mockResponse = {
+      stdout: JSON.stringify({
+        ok: true,
+        result: {
+          id: 58687206,
+          type: "private",
+          first_name: "John",
+        },
+      }),
+      stderr: "",
+      exitCode: 0,
+    };
+
+    const handler = createHandler(config);
+    const result = await handler(["chat", "--chat", "58687206"]);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.output).toContain("John");
+    expect(result.output).toContain("private");
+  });
+
+  it("errors when no chat ID", async () => {
+    const handler = createHandler({ botToken: "test-token" });
+    const result = await handler(["chat"]);
+
+    expect(result.exitCode).toBe(1);
+    expect(result.output).toContain("No chat ID specified");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// updates tests
+// ---------------------------------------------------------------------------
+
+describe("handler - updates", () => {
+  beforeEach(() => {
+    resetMock();
+  });
+
+  const config = {
+    botToken: "test-token-12345",
+  };
+
+  it("returns updates", async () => {
+    mockResponse = {
+      stdout: JSON.stringify({
+        ok: true,
+        result: [
+          {
+            update_id: 123,
+            message: {
+              message_id: 1,
+              chat: { id: 58687206 },
+              text: "/start",
+            },
+          },
+        ],
+      }),
+      stderr: "",
+      exitCode: 0,
+    };
+
+    const handler = createHandler(config);
+    const result = await handler(["updates", "--limit", "10"]);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.output).toContain("update_id");
+    expect(result.output).toContain("58687206");
+  });
+
+  it("errors when botToken not configured", async () => {
+    const handler = createHandler({});
+    const result = await handler(["updates"]);
+
+    expect(result.exitCode).toBe(1);
+    expect(result.output).toContain("botToken not configured");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Subcommand aliases
+// ---------------------------------------------------------------------------
+
+describe("handler - subcommand aliases", () => {
+  beforeEach(() => {
+    resetMock();
+  });
+
+  const config = {
+    botToken: "test-token-12345",
+    defaultChatId: "58687206",
+  };
+
+  it("accepts 'message' as alias for 'send'", async () => {
+    mockResponse = {
+      stdout: JSON.stringify({ ok: true, result: { message_id: 1 } }),
+      stderr: "",
+      exitCode: 0,
+    };
+
+    const handler = createHandler(config);
+    const result = await handler(["message", "--text", "Hello!"]);
+
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("accepts 'msg' as alias for 'send'", async () => {
+    mockResponse = {
+      stdout: JSON.stringify({ ok: true, result: { message_id: 1 } }),
+      stderr: "",
+      exitCode: 0,
+    };
+
+    const handler = createHandler(config);
+    const result = await handler(["msg", "--text", "Hello!"]);
+
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("accepts 'image' as alias for 'photo'", async () => {
+    mockResponse = {
+      stdout: JSON.stringify({ ok: true, result: { message_id: 1 } }),
+      stderr: "",
+      exitCode: 0,
+    };
+
+    const handler = createHandler(config);
+    const result = await handler(["image", "--photo", "https://example.com/img.jpg"]);
+
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("accepts 'doc' as alias for 'document'", async () => {
+    mockResponse = {
+      stdout: JSON.stringify({ ok: true, result: { message_id: 1 } }),
+      stderr: "",
+      exitCode: 0,
+    };
+
+    const handler = createHandler(config);
+    const result = await handler(["doc", "--document", "https://example.com/file.pdf"]);
+
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("accepts 'bot' as alias for 'me'", async () => {
+    mockResponse = {
+      stdout: JSON.stringify({
+        ok: true,
+        result: { id: 123, first_name: "Bot" },
+      }),
+      stderr: "",
+      exitCode: 0,
+    };
+
+    const handler = createHandler(config);
+    const result = await handler(["bot"]);
+
+    expect(result.exitCode).toBe(0);
+  });
+});

--- a/tools/telegram/index.ts
+++ b/tools/telegram/index.ts
@@ -1,0 +1,720 @@
+/**
+ * Telegram Tool for Beige agents
+ *
+ * Send messages, photos, documents, and more to Telegram users and groups.
+ * Supports threads (topics) in supergroups, markdown formatting, and reply-to.
+ *
+ * ── Configuration ─────────────────────────────────────────────────────────────
+ *
+ * Required:
+ *   botToken    — Telegram Bot API token (from @BotFather)
+ *
+ * Optional:
+ *   defaultChatId — Default chat/user ID to send messages to
+ *   defaultParseMode — Default parse mode: "MarkdownV2", "Markdown", "HTML", or none
+ *   allowChats    — Whitelist of chat IDs that can be messaged
+ *   denyChats     — Blacklist of chat IDs (deny beats allow)
+ *   timeout       — Request timeout in seconds (default: 30)
+ *
+ * ── Command Structure ─────────────────────────────────────────────────────────
+ *
+ * All commands follow: telegram <subcommand> [args...]
+ *
+ * The tool uses curl to call the Telegram Bot API directly from the gateway host.
+ */
+
+import { spawn } from "node:child_process";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface TelegramConfig {
+  botToken?: string;
+  defaultChatId?: string | number;
+  defaultParseMode?: "MarkdownV2" | "Markdown" | "HTML";
+  allowChats?: (string | number)[];
+  denyChats?: (string | number)[];
+  timeout?: number;
+}
+
+export interface ParsedCommand {
+  subcommand: string;
+  args: Record<string, string | number | boolean>;
+  rawArgs: string[];
+}
+
+export interface TelegramResponse {
+  ok: boolean;
+  result?: unknown;
+  description?: string;
+  error_code?: number;
+}
+
+// ---------------------------------------------------------------------------
+// API URL builder
+// ---------------------------------------------------------------------------
+
+function apiUrl(token: string, method: string): string {
+  return `https://api.telegram.org/bot${token}/${method}`;
+}
+
+// ---------------------------------------------------------------------------
+// Permission checks
+// ---------------------------------------------------------------------------
+
+function normalizeChatId(chatId: string | number): string {
+  return String(chatId);
+}
+
+function isChatAllowed(
+  chatId: string | number,
+  config: TelegramConfig
+): { allowed: boolean; reason?: string } {
+  const normalizedId = normalizeChatId(chatId);
+
+  // Check deny list first
+  if (config.denyChats) {
+    for (const denied of config.denyChats) {
+      if (normalizeChatId(denied) === normalizedId) {
+        return { allowed: false, reason: `Chat ${chatId} is in deny list` };
+      }
+    }
+  }
+
+  // Check allow list
+  if (config.allowChats) {
+    let matched = false;
+    for (const allowed of config.allowChats) {
+      if (normalizeChatId(allowed) === normalizedId) {
+        matched = true;
+        break;
+      }
+    }
+    if (!matched) {
+      return { allowed: false, reason: `Chat ${chatId} is not in allow list` };
+    }
+  }
+
+  return { allowed: true };
+}
+
+// ---------------------------------------------------------------------------
+// Argument parsing
+// ---------------------------------------------------------------------------
+
+function parseBoolean(value: string): boolean {
+  return value.toLowerCase() === "true" || value === "1" || value.toLowerCase() === "yes";
+}
+
+function parseArgs(args: string[]): ParsedCommand {
+  if (args.length === 0) {
+    return { subcommand: "", args: {}, rawArgs: args };
+  }
+
+  const subcommand = args[0];
+  const parsed: Record<string, string | number | boolean> = {};
+  let i = 1;
+
+  while (i < args.length) {
+    const arg = args[i];
+
+    // Handle --key value or --key=value
+    if (arg.startsWith("--")) {
+      const eqIndex = arg.indexOf("=");
+      let key: string;
+      let value: string;
+
+      if (eqIndex !== -1) {
+        key = arg.slice(2, eqIndex);
+        value = arg.slice(eqIndex + 1);
+      } else if (i + 1 < args.length && !args[i + 1].startsWith("--")) {
+        key = arg.slice(2);
+        value = args[i + 1];
+        i++;
+      } else {
+        // Boolean flag
+        key = arg.slice(2);
+        value = "true";
+      }
+
+      // Convert numeric values
+      if (/^-?\d+$/.test(value)) {
+        parsed[key] = parseInt(value, 10);
+      } else if (/^-?\d+\.\d+$/.test(value)) {
+        parsed[key] = parseFloat(value);
+      } else if (value === "true" || value === "false") {
+        parsed[key] = parseBoolean(value);
+      } else {
+        parsed[key] = value;
+      }
+    }
+
+    i++;
+  }
+
+  return { subcommand, args: parsed, rawArgs: args };
+}
+
+// ---------------------------------------------------------------------------
+// HTTP Request executor using curl
+// ---------------------------------------------------------------------------
+
+interface CurlResult {
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+}
+
+function executeCurl(
+  args: string[],
+  timeoutSeconds: number
+): Promise<CurlResult> {
+  return new Promise((resolve) => {
+    const proc = spawn("curl", args, {
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    let stdout = "";
+    let stderr = "";
+
+    proc.stdout?.on("data", (data) => {
+      stdout += data.toString();
+    });
+
+    proc.stderr?.on("data", (data) => {
+      stderr += data.toString();
+    });
+
+    proc.on("close", (code) => {
+      resolve({ stdout, stderr, exitCode: code ?? 1 });
+    });
+
+    // Timeout
+    setTimeout(() => {
+      proc.kill();
+      resolve({
+        stdout: "",
+        stderr: `Request timed out after ${timeoutSeconds} seconds`,
+        exitCode: 1,
+      });
+    }, timeoutSeconds * 1000);
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Command handlers
+// ---------------------------------------------------------------------------
+
+async function handleSendMessage(
+  parsed: ParsedCommand,
+  config: TelegramConfig
+): Promise<{ output: string; exitCode: number }> {
+  const chatId = parsed.args.chat ?? parsed.args.chatId ?? config.defaultChatId;
+  if (!chatId) {
+    return {
+      output: "Error: No chat ID specified. Use --chat or configure defaultChatId.",
+      exitCode: 1,
+    };
+  }
+
+  const text = parsed.args.text ?? parsed.args.message;
+  if (!text) {
+    return { output: "Error: No message text specified. Use --text.", exitCode: 1 };
+  }
+
+  // Check permissions
+  const permCheck = isChatAllowed(chatId, config);
+  if (!permCheck.allowed) {
+    return { output: `Permission denied: ${permCheck.reason}`, exitCode: 1 };
+  }
+
+  if (!config.botToken) {
+    return { output: "Error: botToken not configured.", exitCode: 1 };
+  }
+
+  // Build request
+  const jsonPayload: Record<string, unknown> = {
+    chat_id: chatId,
+    text: String(text),
+  };
+
+  // Parse mode
+  const parseMode = parsed.args.parseMode ?? config.defaultParseMode;
+  if (parseMode) {
+    jsonPayload.parse_mode = parseMode;
+  }
+
+  // Thread/topic support (for supergroups with topics)
+  const threadId = parsed.args.thread ?? parsed.args.threadId ?? parsed.args.messageThreadId;
+  if (threadId) {
+    jsonPayload.message_thread_id = threadId;
+  }
+
+  // Reply to message
+  if (parsed.args.replyTo) {
+    jsonPayload.reply_to_message_id = parsed.args.replyTo;
+  }
+
+  // Disable notification
+  if (parsed.args.silent || parsed.args.disableNotification) {
+    jsonPayload.disable_notification = true;
+  }
+
+  // Disable web page preview
+  if (parsed.args.disablePreview || parsed.args.disableWebPagePreview) {
+    jsonPayload.disable_web_page_preview = true;
+  }
+
+  // Execute request
+  const url = apiUrl(config.botToken, "sendMessage");
+  const curlArgs = [
+    "-s",
+    "-X", "POST",
+    "-H", "Content-Type: application/json",
+    "-d", JSON.stringify(jsonPayload),
+    "--max-time", String(config.timeout ?? 30),
+    url,
+  ];
+
+  const result = await executeCurl(curlArgs, config.timeout ?? 30);
+
+  if (result.exitCode !== 0) {
+    return { output: `Error: ${result.stderr || result.stdout}`, exitCode: 1 };
+  }
+
+  try {
+    const response: TelegramResponse = JSON.parse(result.stdout);
+    if (!response.ok) {
+      return {
+        output: `Telegram API error: ${response.description} (code ${response.error_code})`,
+        exitCode: 1,
+      };
+    }
+    return { output: `Message sent successfully to chat ${chatId}`, exitCode: 0 };
+  } catch {
+    return { output: `Unexpected response: ${result.stdout}`, exitCode: 1 };
+  }
+}
+
+async function handleSendPhoto(
+  parsed: ParsedCommand,
+  config: TelegramConfig
+): Promise<{ output: string; exitCode: number }> {
+  const chatId = parsed.args.chat ?? parsed.args.chatId ?? config.defaultChatId;
+  if (!chatId) {
+    return {
+      output: "Error: No chat ID specified. Use --chat or configure defaultChatId.",
+      exitCode: 1,
+    };
+  }
+
+  const photo = parsed.args.photo ?? parsed.args.url ?? parsed.args.file;
+  if (!photo) {
+    return { output: "Error: No photo specified. Use --photo with a URL or file path.", exitCode: 1 };
+  }
+
+  // Check permissions
+  const permCheck = isChatAllowed(chatId, config);
+  if (!permCheck.allowed) {
+    return { output: `Permission denied: ${permCheck.reason}`, exitCode: 1 };
+  }
+
+  if (!config.botToken) {
+    return { output: "Error: botToken not configured.", exitCode: 1 };
+  }
+
+  // Build request
+  const jsonPayload: Record<string, unknown> = {
+    chat_id: chatId,
+    photo: String(photo),
+  };
+
+  // Caption
+  if (parsed.args.caption) {
+    jsonPayload.caption = String(parsed.args.caption);
+  }
+
+  // Parse mode for caption
+  const parseMode = parsed.args.parseMode ?? config.defaultParseMode;
+  if (parseMode && parsed.args.caption) {
+    jsonPayload.parse_mode = parseMode;
+  }
+
+  // Thread/topic support
+  const threadId = parsed.args.thread ?? parsed.args.threadId ?? parsed.args.messageThreadId;
+  if (threadId) {
+    jsonPayload.message_thread_id = threadId;
+  }
+
+  // Reply to message
+  if (parsed.args.replyTo) {
+    jsonPayload.reply_to_message_id = parsed.args.replyTo;
+  }
+
+  // Disable notification
+  if (parsed.args.silent || parsed.args.disableNotification) {
+    jsonPayload.disable_notification = true;
+  }
+
+  // Execute request
+  const url = apiUrl(config.botToken, "sendPhoto");
+  const curlArgs = [
+    "-s",
+    "-X", "POST",
+    "-H", "Content-Type: application/json",
+    "-d", JSON.stringify(jsonPayload),
+    "--max-time", String(config.timeout ?? 30),
+    url,
+  ];
+
+  const result = await executeCurl(curlArgs, config.timeout ?? 30);
+
+  if (result.exitCode !== 0) {
+    return { output: `Error: ${result.stderr || result.stdout}`, exitCode: 1 };
+  }
+
+  try {
+    const response: TelegramResponse = JSON.parse(result.stdout);
+    if (!response.ok) {
+      return {
+        output: `Telegram API error: ${response.description} (code ${response.error_code})`,
+        exitCode: 1,
+      };
+    }
+    return { output: `Photo sent successfully to chat ${chatId}`, exitCode: 0 };
+  } catch {
+    return { output: `Unexpected response: ${result.stdout}`, exitCode: 1 };
+  }
+}
+
+async function handleSendDocument(
+  parsed: ParsedCommand,
+  config: TelegramConfig
+): Promise<{ output: string; exitCode: number }> {
+  const chatId = parsed.args.chat ?? parsed.args.chatId ?? config.defaultChatId;
+  if (!chatId) {
+    return {
+      output: "Error: No chat ID specified. Use --chat or configure defaultChatId.",
+      exitCode: 1,
+    };
+  }
+
+  const docUrl = parsed.args.document ?? parsed.args.url ?? parsed.args.file;
+  if (!docUrl) {
+    return { output: "Error: No document specified. Use --document with a URL or file_id.", exitCode: 1 };
+  }
+
+  // Check permissions
+  const permCheck = isChatAllowed(chatId, config);
+  if (!permCheck.allowed) {
+    return { output: `Permission denied: ${permCheck.reason}`, exitCode: 1 };
+  }
+
+  if (!config.botToken) {
+    return { output: "Error: botToken not configured.", exitCode: 1 };
+  }
+
+  // Build request
+  const jsonPayload: Record<string, unknown> = {
+    chat_id: chatId,
+    document: String(docUrl),
+  };
+
+  // Caption
+  if (parsed.args.caption) {
+    jsonPayload.caption = String(parsed.args.caption);
+  }
+
+  // Parse mode for caption
+  const parseMode = parsed.args.parseMode ?? config.defaultParseMode;
+  if (parseMode && parsed.args.caption) {
+    jsonPayload.parse_mode = parseMode;
+  }
+
+  // Thread/topic support
+  const docThreadId = parsed.args.thread ?? parsed.args.threadId ?? parsed.args.messageThreadId;
+  if (docThreadId) {
+    jsonPayload.message_thread_id = docThreadId;
+  }
+
+  // Reply to message
+  if (parsed.args.replyTo) {
+    jsonPayload.reply_to_message_id = parsed.args.replyTo;
+  }
+
+  // Disable notification
+  if (parsed.args.silent || parsed.args.disableNotification) {
+    jsonPayload.disable_notification = true;
+  }
+
+  // Execute request
+  const url = apiUrl(config.botToken, "sendDocument");
+  const curlArgs = [
+    "-s",
+    "-X", "POST",
+    "-H", "Content-Type: application/json",
+    "-d", JSON.stringify(jsonPayload),
+    "--max-time", String(config.timeout ?? 30),
+    url,
+  ];
+
+  const result = await executeCurl(curlArgs, config.timeout ?? 30);
+
+  if (result.exitCode !== 0) {
+    return { output: `Error: ${result.stderr || result.stdout}`, exitCode: 1 };
+  }
+
+  try {
+    const response: TelegramResponse = JSON.parse(result.stdout);
+    if (!response.ok) {
+      return {
+        output: `Telegram API error: ${response.description} (code ${response.error_code})`,
+        exitCode: 1,
+      };
+    }
+    return { output: `Document sent successfully to chat ${chatId}`, exitCode: 0 };
+  } catch {
+    return { output: `Unexpected response: ${result.stdout}`, exitCode: 1 };
+  }
+}
+
+async function handleGetMe(
+  config: TelegramConfig
+): Promise<{ output: string; exitCode: number }> {
+  if (!config.botToken) {
+    return { output: "Error: botToken not configured.", exitCode: 1 };
+  }
+
+  const url = apiUrl(config.botToken, "getMe");
+  const curlArgs = ["-s", "--max-time", String(config.timeout ?? 30), url];
+
+  const result = await executeCurl(curlArgs, config.timeout ?? 30);
+
+  if (result.exitCode !== 0) {
+    return { output: `Error: ${result.stderr || result.stdout}`, exitCode: 1 };
+  }
+
+  try {
+    const response: TelegramResponse = JSON.parse(result.stdout);
+    if (!response.ok) {
+      return {
+        output: `Telegram API error: ${response.description} (code ${response.error_code})`,
+        exitCode: 1,
+      };
+    }
+    return { output: JSON.stringify(response.result, null, 2), exitCode: 0 };
+  } catch {
+    return { output: `Unexpected response: ${result.stdout}`, exitCode: 1 };
+  }
+}
+
+async function handleGetChat(
+  parsed: ParsedCommand,
+  config: TelegramConfig
+): Promise<{ output: string; exitCode: number }> {
+  const chatId = parsed.args.chat ?? parsed.args.chatId ?? config.defaultChatId;
+  if (!chatId) {
+    return {
+      output: "Error: No chat ID specified. Use --chat or configure defaultChatId.",
+      exitCode: 1,
+    };
+  }
+
+  if (!config.botToken) {
+    return { output: "Error: botToken not configured.", exitCode: 1 };
+  }
+
+  const url = apiUrl(config.botToken, "getChat");
+  const curlArgs = [
+    "-s",
+    "-X", "POST",
+    "-H", "Content-Type: application/json",
+    "-d", JSON.stringify({ chat_id: chatId }),
+    "--max-time", String(config.timeout ?? 30),
+    url,
+  ];
+
+  const result = await executeCurl(curlArgs, config.timeout ?? 30);
+
+  if (result.exitCode !== 0) {
+    return { output: `Error: ${result.stderr || result.stdout}`, exitCode: 1 };
+  }
+
+  try {
+    const response: TelegramResponse = JSON.parse(result.stdout);
+    if (!response.ok) {
+      return {
+        output: `Telegram API error: ${response.description} (code ${response.error_code})`,
+        exitCode: 1,
+      };
+    }
+    return { output: JSON.stringify(response.result, null, 2), exitCode: 0 };
+  } catch {
+    return { output: `Unexpected response: ${result.stdout}`, exitCode: 1 };
+  }
+}
+
+async function handleGetUpdates(
+  parsed: ParsedCommand,
+  config: TelegramConfig
+): Promise<{ output: string; exitCode: number }> {
+  if (!config.botToken) {
+    return { output: "Error: botToken not configured.", exitCode: 1 };
+  }
+
+  const jsonPayload: Record<string, unknown> = {};
+
+  if (parsed.args.offset) {
+    jsonPayload.offset = parsed.args.offset;
+  }
+  if (parsed.args.limit) {
+    jsonPayload.limit = parsed.args.limit;
+  }
+  if (parsed.args.timeout !== undefined) {
+    jsonPayload.timeout = parsed.args.timeout;
+  }
+
+  const url = apiUrl(config.botToken, "getUpdates");
+  const curlArgs = [
+    "-s",
+    "-X", "POST",
+    "-H", "Content-Type: application/json",
+    "-d", JSON.stringify(jsonPayload),
+    "--max-time", String((config.timeout ?? 30) + (jsonPayload.timeout as number || 0)),
+    url,
+  ];
+
+  const result = await executeCurl(curlArgs, (config.timeout ?? 30) + (jsonPayload.timeout as number || 0));
+
+  if (result.exitCode !== 0) {
+    return { output: `Error: ${result.stderr || result.stdout}`, exitCode: 1 };
+  }
+
+  try {
+    const response: TelegramResponse = JSON.parse(result.stdout);
+    if (!response.ok) {
+      return {
+        output: `Telegram API error: ${response.description} (code ${response.error_code})`,
+        exitCode: 1,
+      };
+    }
+    return { output: JSON.stringify(response.result, null, 2), exitCode: 0 };
+  } catch {
+    return { output: `Unexpected response: ${result.stdout}`, exitCode: 1 };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Usage text
+// ---------------------------------------------------------------------------
+
+function usageText(): string {
+  return [
+    "Telegram Tool — Send messages and media via Telegram Bot API",
+    "",
+    "Usage: telegram <subcommand> [options]",
+    "",
+    "Subcommands:",
+    "  send        Send a text message",
+    "  photo       Send a photo",
+    "  document    Send a document/file",
+    "  me          Get bot info",
+    "  chat        Get chat info",
+    "  updates     Get pending updates",
+    "",
+    "Send message options:",
+    "  --chat <id>       Chat/user ID (or use defaultChatId config)",
+    "  --text <message>  Message text to send",
+    "  --thread <id>     Thread/topic ID (for supergroups)",
+    "  --reply-to <id>   Message ID to reply to",
+    "  --parse-mode <mode>  Markdown, MarkdownV2, or HTML",
+    "  --silent          Send without notification",
+    "  --disable-preview Disable link previews",
+    "",
+    "Send photo options:",
+    "  --chat <id>       Chat/user ID",
+    "  --photo <url|file_id>  Photo URL or file_id",
+    "  --caption <text>  Photo caption",
+    "  --thread <id>     Thread/topic ID",
+    "  --reply-to <id>   Message ID to reply to",
+    "",
+    "Examples:",
+    "  telegram send --chat 58687206 --text \"Hello from beige!\"",
+    "  telegram send --chat 58687206 --text \"*Bold*\" --parse-mode Markdown",
+    "  telegram photo --chat 58687206 --photo https://example.com/image.jpg",
+    "  telegram document --chat 58687206 --document https://example.com/file.pdf",
+    "  telegram me",
+    "  telegram chat --chat 58687206",
+    "  telegram updates --limit 10",
+  ].join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// Main handler factory
+// ---------------------------------------------------------------------------
+
+export function createHandler(
+  rawConfig: Record<string, unknown>
+): (args: string[]) => Promise<{ output: string; exitCode: number }> {
+  const config: TelegramConfig = {
+    botToken: rawConfig.botToken as string | undefined,
+    defaultChatId: rawConfig.defaultChatId as string | number | undefined,
+    defaultParseMode: rawConfig.defaultParseMode as "MarkdownV2" | "Markdown" | "HTML" | undefined,
+    allowChats: rawConfig.allowChats as (string | number)[] | undefined,
+    denyChats: rawConfig.denyChats as (string | number)[] | undefined,
+    timeout: (rawConfig.timeout as number) ?? 30,
+  };
+
+  return async (args: string[]) => {
+    if (args.length === 0) {
+      return { output: usageText(), exitCode: 1 };
+    }
+
+    const parsed = parseArgs(args);
+    const subcommand = parsed.subcommand.toLowerCase();
+
+    switch (subcommand) {
+      case "send":
+      case "message":
+      case "msg":
+        return handleSendMessage(parsed, config);
+
+      case "photo":
+      case "image":
+      case "img":
+        return handleSendPhoto(parsed, config);
+
+      case "document":
+      case "doc":
+      case "file":
+        return handleSendDocument(parsed, config);
+
+      case "me":
+      case "bot":
+      case "self":
+        return handleGetMe(config);
+
+      case "chat":
+      case "info":
+        return handleGetChat(parsed, config);
+
+      case "updates":
+      case "poll":
+        return handleGetUpdates(parsed, config);
+
+      case "help":
+      case "--help":
+        return { output: usageText(), exitCode: 0 };
+
+      default:
+        return {
+          output: `Unknown subcommand: ${subcommand}\n\n${usageText()}`,
+          exitCode: 1,
+        };
+    }
+  };
+}
+
+// Export utilities for testing
+export { isChatAllowed, parseArgs, apiUrl };

--- a/tools/telegram/package.json
+++ b/tools/telegram/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@beige/tool-telegram",
+  "private": true,
+  "type": "module"
+}

--- a/tools/telegram/tool.json
+++ b/tools/telegram/tool.json
@@ -1,0 +1,49 @@
+{
+  "name": "telegram",
+  "description": "Send messages, photos, documents, and more to Telegram users and groups via the Bot API. Supports threads (topics) in supergroups, markdown/HTML formatting, reply-to, and read-only operations like getting bot info and chat details.",
+  "commands": [
+    "send --chat <id> --text <message> [--thread <id>] [--reply-to <msg-id>] [--parse-mode <mode>] [--silent] [--disable-preview]  — Send a text message",
+    "photo --chat <id> --photo <url|file_id> [--caption <text>] [--thread <id>] [--reply-to <msg-id>]  — Send a photo",
+    "document --chat <id> --document <url|file_id> [--caption <text>] [--thread <id>]  — Send a document/file",
+    "me  — Get bot information",
+    "chat --chat <id>  — Get chat information",
+    "updates [--limit <n>] [--offset <id>]  — Get pending updates"
+  ],
+  "target": "gateway",
+  "config": {
+    "botToken": {
+      "type": "string",
+      "description": "Telegram Bot API token from @BotFather. Required for all operations.",
+      "required": true,
+      "secret": true,
+      "example": "1234567890:ABCdefGHIjklMNOpqrsTUVwxyz"
+    },
+    "defaultChatId": {
+      "type": "string | number",
+      "description": "Default chat/user ID to send messages to. Can be overridden with --chat flag.",
+      "example": "58687206"
+    },
+    "defaultParseMode": {
+      "type": "string",
+      "description": "Default parse mode for message formatting. Options: MarkdownV2, Markdown, HTML.",
+      "enum": ["MarkdownV2", "Markdown", "HTML"],
+      "example": "MarkdownV2"
+    },
+    "allowChats": {
+      "type": "array[string | number]",
+      "description": "Whitelist of chat IDs that can be messaged. If set, only these chats can receive messages.",
+      "example": ["58687206", "-1001234567890"]
+    },
+    "denyChats": {
+      "type": "array[string | number]",
+      "description": "Blacklist of chat IDs that cannot be messaged. Takes precedence over allowChats.",
+      "example": ["-1001234567890"]
+    },
+    "timeout": {
+      "type": "number",
+      "description": "Request timeout in seconds. Default: 30.",
+      "default": 30,
+      "example": 60
+    }
+  }
+}


### PR DESCRIPTION
Adds comprehensive Telegram Bot API integration for Beige agents.

## Features
- **Text messages** - Send formatted text with Markdown, MarkdownV2, or HTML
- **Photos** - Send images by URL or file_id with captions
- **Documents** - Send files by URL or file_id with captions
- **Thread/topic support** - Post to specific topics in Telegram supergroups
- **Reply-to** - Reply to specific messages
- **Silent mode** - Send without notification
- **Link preview control** - Disable web page previews
- **Chat filtering** - allowChats/denyChats for security
- **Bot info** - Get bot details
- **Chat info** - Get chat information
- **Get updates** - Poll for new messages

## Usage
```bash
# Send a message
/tools/bin/telegram send --chat 58687206 --text "Hello from beige!"

# Post to a thread/topic in a supergroup
/tools/bin/telegram send --chat -100123456789 --thread 42 --text "Topic reply"

# Send a photo
/tools/bin/telegram photo --chat 58687206 --url https://example.com/image.jpg --caption "Check this out!"

# Send a document
/tools/bin/telegram document --chat 58687206 --url https://example.com/file.pdf

# Get bot info
/tools/bin/telegram bot-info
```

## Configuration
```json5
{
  tools: {
    telegram: {
      config: {
        botToken: "YOUR_BOT_TOKEN",
        defaultChatId: "58687206",
        defaultParseMode: "Markdown",
        allowChats: ["58687206", "-100123456789"],
      },
    },
  },
}
```

## Files Added
- `tools/telegram/index.ts` - Main implementation (~720 lines)
- `tools/telegram/tool.json` - Tool metadata and config schema
- `tools/telegram/README.md` - Full documentation
- `tools/telegram/SKILL.md` - Usage guide for agents
- `tools/telegram/package.json` - Package metadata
- `tools/telegram/__tests__/unit.test.ts` - Comprehensive unit tests

## Testing
Unit tests cover:
- Argument parsing and validation
- Chat permission checks (allow/deny lists)
- Message sending with all options (parse mode, silent, etc.)
- Photo and document sending
- Thread/topic support
- Bot and chat info retrieval
- Subcommand aliases (send/msg/message, photo/img/image, etc.)

Closes #6