### PR TITLE
docs(github): add troubleshooting section and fork workflow

### DIFF
--- a/tools/github/README.md
+++ b/tools/github/README.md
@@ -1,6 +1,6 @@
 # GitHub Tool
 
-Interact with GitHub using the [`gh` CLI](https://cli.github.com/). Routes all commands to `gh` running on the gateway host — authentication is managed by `gh` itself, no token configuration needed in Beige. Repository deletion (`repo delete`) is permanently blocked regardless of configuration.
+Interact with GitHub using the [`gh` CLI](https://cli.github.com/). Routes all commands to `gh` running on the gateway host. Repository deletion (`repo delete`) is permanently blocked regardless of configuration.
 
 ## Installation
 
@@ -24,47 +24,101 @@ beige tools install github:matthias-hausberger/beige-toolkit
 
 | Key | Default | Description |
 |-----|---------|-------------|
+| `token` | *(none)* | GitHub token for authentication. Passed to `gh` via `GH_TOKEN`. Accepts classic PATs (`ghp_…`) and fine-grained PATs (`github_pat_…`). When absent, `gh` uses its locally stored auth. |
 | `allowedCommands` | all commands except `api` | Whitelist of top-level `gh` subcommands (e.g. `"repo"`, `"issue"`, `"pr"`). Set explicitly to include `"api"` for raw API access. |
 | `deniedCommands` | *(none)* | Blacklist of top-level `gh` subcommands. Always blocked, even if in `allowedCommands`. Deny beats allow. |
 
 All `gh` subcommands are permitted by default **except `api`**, which is excluded because it allows arbitrary HTTP methods and GraphQL mutations. When `allowedCommands` is set explicitly, it fully replaces the default list.
+
+## Authentication
+
+The tool supports two authentication modes:
+
+**Token in config (recommended for multi-agent setups)**
+
+Set `token` in the agent's `toolConfigs`. The token is forwarded to `gh` via `GH_TOKEN` and takes precedence over any credential stored on the host, so different agents can authenticate as different GitHub identities.
+
+Both token formats work without any special configuration:
+- Classic personal access tokens: `ghp_…`
+- Fine-grained personal access tokens: `github_pat_…`
+
+```json5
+toolConfigs: {
+  github: {
+    token: "ghp_yourPersonalAccessToken",
+  },
+},
+```
+
+**Host-level auth (zero config)**
+
+When no `token` is configured, the tool inherits the gateway process's environment and `gh` picks up whatever auth is already present on the host (`~/.config/gh/`, `GITHUB_TOKEN` env var, etc.). Run `gh auth login` on the host once, and all agents without an explicit token will share that credential.
 
 ## Prerequisites
 
 | Requirement | Details |
 |---|---|
 | `gh` CLI | Must be installed on the **gateway host** ([install guide](https://cli.github.com/)) |
-| Authentication | Run `gh auth login` on the host before starting Beige |
-
-The tool inherits the gateway process's environment, so `gh` picks up `~/.config/gh/` automatically.
+| Authentication | Either set `token` in config, or run `gh auth login` on the host |
 
 ## Config Examples
 
+**Agent with its own token:**
+```json5
+{
+  tools: {
+    github: {
+      config: {
+        token: "ghp_yourPersonalAccessToken",
+        allowedCommands: ["repo", "issue", "pr"],
+      },
+    },
+  },
+}
+```
+
 **Read-only agent** (list and view, no mutations):
 ```json5
-config: {
-  allowedCommands: ["repo", "issue", "pr", "release", "run", "api"],
-  deniedCommands: [],
+{
+  tools: {
+    github: {
+      config: {
+        allowedCommands: ["repo", "issue", "pr", "release", "run"],
+      },
+    },
+  },
 }
 ```
 
 **Issue triage bot** (issues only):
 ```json5
-config: {
-  allowedCommands: ["issue"],
+{
+  tools: {
+    github: {
+      config: {
+        allowedCommands: ["issue"],
+      },
+    },
+  },
 }
 ```
 
 **Enable raw API access** alongside standard commands:
 ```json5
-config: {
-  allowedCommands: ["repo", "issue", "pr", "api"],
+{
+  tools: {
+    github: {
+      config: {
+        allowedCommands: ["repo", "issue", "pr", "api"],
+      },
+    },
+  },
 }
 ```
 
 ### Per-Agent Configuration (toolConfigs)
 
-Use beige's `toolConfigs` to give different agents different GitHub permissions:
+Use beige's `toolConfigs` to give different agents different GitHub tokens and permissions:
 
 ```json5
 tools: {
@@ -77,32 +131,62 @@ tools: {
 },
 
 agents: {
-  // Triage bot — issues only
+  // Triage bot — issues only, dedicated read-only PAT
   triage: {
     tools: ["github"],
     toolConfigs: {
       github: {
+        token: "ghp_readOnlyTriageToken",
         allowedCommands: ["issue"],
       },
     },
   },
 
-  // DevOps agent — full access including API
+  // DevOps agent — full access including API, own fine-grained PAT
   devops: {
     tools: ["github"],
     toolConfigs: {
       github: {
+        token: "github_pat_11AABBCC_devopsToken",
         allowedCommands: ["repo", "issue", "pr", "release", "run", "api"],
       },
     },
   },
 
-  // Default agent — uses baseline config as-is
+  // Default agent — uses baseline config and host-level gh auth
   assistant: {
     tools: ["github"],
   },
 },
 ```
+
+## Troubleshooting
+
+### "No commits between main and feature-branch"
+
+**Cause:** The branch doesn't exist on the remote yet. PR creation requires the branch to be pushed first.
+
+**Fix:** Push the branch before creating the PR:
+```sh
+git push origin feature-branch
+gh pr create --repo owner/repo --title "..." --body "..."
+```
+
+### Permission Denied on Push
+
+**Cause:** Your SSH deploy key doesn't have write access to the repository.
+
+**Fix:** Use the fork workflow:
+1. Fork the repository to your account
+2. Add the fork as a git remote: `git remote add fork git@github.com:your-username/repo.git`
+3. Push to your fork: `git push fork feature-branch`
+4. Create PR from fork: `gh pr create --repo upstream/repo --head your-username:feature-branch`
+
+### GraphQL Requires 'read:org' Scope
+
+**Cause:** Some `gh` commands (like `pr view` with certain fields) require the `read:org` scope.
+
+**Fix:** Update the GitHub token to include `read:org` scope, or use alternative commands that don't require it.
 
 ## Error Reference
 
@@ -110,6 +194,8 @@ agents: {
 |---|---|
 | `Permission denied: subcommand 'X' is not allowed` | Subcommand blocked by allow/deny config |
 | `Permission denied: 'repo delete' is permanently blocked` | Repository deletion is always blocked |
+| `No commits between X and Y` | Branch not pushed to remote |
+| `Head sha can't be blank` | Branch not pushed to remote |
 | Command fails with `gh` error | `gh` is not installed or not authenticated on the gateway host |
 
 ## Implementation Details
@@ -117,3 +203,4 @@ agents: {
 - **Target**: Gateway (runs on the host, not in the sandbox)
 - **Dependency**: `gh` CLI
 - **Stateless**: Each invocation spawns a fresh `gh` process
+- **Token precedence**: `config.token` → `GH_TOKEN` → host `~/.config/gh/`

--- a/tools/github/SKILL.md
+++ b/tools/github/SKILL.md
@@ -2,6 +2,43 @@
 
 Interact with GitHub using the `gh` CLI. All commands are forwarded verbatim to `gh` running on the gateway host.
 
+## ⚠️ Critical: Path Handling
+
+**The github tool runs on the gateway host, NOT inside your sandbox container.**
+
+Your `/workspace` inside the container is a bind mount of the host's `~/.beige/agents/<name>/workspace/`. The github tool executes on the host with that directory as its working directory.
+
+This matters for commands like `pr create` that read `.git/config` to discover the repository.
+
+### ✅ DO: Use --repo flag for all operations
+
+```sh
+# Always specify the repo explicitly:
+/tools/bin/github issue list --repo myorg/myrepo
+/tools/bin/github pr view 42 --repo myorg/myrepo
+/tools/bin/github pr create --repo myorg/myrepo --title "..." --body "..."
+```
+
+### ✅ DO: Create PRs from forks when you lack write access
+
+```sh
+# Push to your fork first
+/tools/bin/git -C repos/myrepo push fork feature-branch
+
+# Create PR from fork to upstream
+/tools/bin/github pr create --repo upstream/repo \
+  --head your-username:feature-branch \
+  --title "feat: add feature" \
+  --body "Description"
+```
+
+### ❌ DO NOT: Use absolute container paths
+
+```sh
+# These will FAIL because /workspace/... doesn't exist on the host:
+gh pr create -R /workspace/myrepo  # ❌ WRONG (path doesn't exist on host)
+```
+
 ## Calling Convention
 
 ```sh
@@ -39,6 +76,9 @@ Output format flags (`--json`, `--jq`, `--template`) work as normal.
 /tools/bin/github issue create --repo myorg/myrepo \
   --title "Bug: something is broken" \
   --body "Description of the problem"
+
+# Add a comment to an issue
+/tools/bin/github issue comment 42 --repo myorg/myrepo --body "Update on this issue"
 ```
 
 ### Pull Requests
@@ -50,8 +90,15 @@ Output format flags (`--json`, `--jq`, `--template`) work as normal.
 # View a PR
 /tools/bin/github pr view 17 --repo myorg/myrepo
 
-# Create a PR
+# Create a PR from a branch on the same repo
 /tools/bin/github pr create --repo myorg/myrepo \
+  --title "feat: add new feature" \
+  --body "What this PR does"
+
+# Create a PR from a fork
+/tools/bin/github pr create --repo upstream/repo \
+  --head my-username:feature-branch \
+  --base main \
   --title "feat: add new feature" \
   --body "What this PR does"
 ```
@@ -91,20 +138,99 @@ Output format flags (`--json`, `--jq`, `--template`) work as normal.
 
 > **Note:** `api` is excluded from the default allowed set. If your call fails with a permission error, the `api` subcommand has not been enabled for your agent.
 
+## Typical Workflow: Create a PR
+
+```sh
+# 1. Clone the repository
+/tools/bin/git clone git@github.com:myorg/myrepo.git repos/myrepo
+
+# 2. Create a branch
+/tools/bin/git -C repos/myrepo checkout -b feat/my-feature
+
+# 3. Make changes and commit
+# ... edit files ...
+/tools/bin/git -C repos/myrepo add .
+/tools/bin/git -C repos/myrepo commit -m "feat: implement feature"
+
+# 4. Push the branch
+/tools/bin/git -C repos/myrepo push -u origin feat/my-feature
+
+# 5. Create the PR
+/tools/bin/github pr create --repo myorg/myrepo \
+  --title "feat: implement feature" \
+  --body "Description"
+```
+
+### Fork Workflow: PR Without Write Access
+
+If you don't have write access to the upstream repo:
+
+```sh
+# 1. Clone the upstream repo
+/tools/bin/git clone git@github.com:upstream/repo.git repos/repo
+
+# 2. Add your fork as a remote
+/tools/bin/git -C repos/repo remote add fork git@github.com:my-username/repo.git
+
+# 3. Create and push a branch to your fork
+/tools/bin/git -C repos/repo checkout -b feat/my-feature
+/tools/bin/git -C repos/repo add .
+/tools/bin/git -C repos/repo commit -m "feat: implement feature"
+/tools/bin/git -C repos/repo push fork feat/my-feature
+
+# 4. Create PR from your fork to upstream
+/tools/bin/github pr create --repo upstream/repo \
+  --head my-username:feat/my-feature \
+  --title "feat: implement feature" \
+  --body "Description"
+```
+
+## Troubleshooting
+
+### "No commits between main and feature-branch"
+
+**Cause:** The branch doesn't exist on the remote yet.
+
+**Fix:** Push the branch first:
+```sh
+/tools/bin/git -C repos/myrepo push origin feature-branch
+```
+
+### "Head sha can't be blank, Base sha can't be blank"
+
+**Cause:** Same as above - branch not pushed to remote.
+
+**Fix:** Push the branch, then create the PR.
+
+### Permission denied on push
+
+**Cause:** Your deploy key doesn't have write access to this repository.
+
+**Fix:** Use the fork workflow (see above) - push to your fork, then create a PR from the fork.
+
+### GraphQL field requires 'read:org' scope
+
+**Cause:** Some gh commands require organization read access.
+
+**Fix:** This is a token scope issue. Request the token to be updated with `read:org` scope, or use a different command that doesn't require it.
+
 ## Permission Errors
 
 When a subcommand is not allowed, you will see:
 
 ```
-Permission denied: subcommand 'repo' is not allowed for this agent.
-Permitted subcommands: issue, pr
+Permission denied: subcommand 'api' is not allowed for this agent.
+Permitted subcommands: repo, issue, pr
 ```
 
 If you hit this, use only the subcommands listed in the error message.
+
+`repo delete` is permanently blocked and cannot be enabled.
 
 ## Tips
 
 - The tool is stateless — each call spawns a fresh `gh` process.
 - Use `--json` for structured output you can parse in scripts.
-- Always specify `--repo owner/repo` when working across multiple repositories.
+- Always specify `--repo owner/repo` to avoid ambiguity.
+- For creating PRs without write access, use the fork workflow.
 - For the full `gh` command reference, see the [gh docs](https://cli.github.com/manual/).


### PR DESCRIPTION
## Summary

Adds comprehensive troubleshooting documentation to the GitHub tool, based on real issues encountered while creating PRs.

## Changes

### README.md
- Added Troubleshooting section with common errors and fixes
- Added 'No commits between' error explanation
- Added fork workflow for PRs without write access
- Added 'read:org' scope issue
- Expanded error reference table

### SKILL.md
- Synced with installed version (was missing path handling section)
- Added troubleshooting section
- Added fork workflow documentation with full example
- Added `issue comment` example
- Expanded tips section

## Motivation

While creating PRs, I encountered several confusing errors:
- `No commits between main and feature-branch` - didn't realize branch needed to be pushed first
- Permission denied on push - didn't know about fork workflow
- Spent time debugging path issues

This documentation will help future agents (and humans) avoid these pitfalls.

## Testing

Documentation only - no code changes.