### PR TITLE
feat: add Diff tool for comparing files and directories

### DIFF
--- a/tools/diff/README.md
+++ b/tools/diff/README.md
@@ -1,0 +1,168 @@
+# Diff Tool
+
+Compare files and directories to find differences.
+
+## Installation
+
+```bash
+# Clone or copy to your beige-toolkit tools directory
+```
+
+## Commands
+
+### `diff files <file1> <file2>`
+
+Compare two files and show line-by-line differences.
+
+```bash
+diff files old.txt new.txt
+diff files src.ts dest.ts -c 5  # 5 context lines
+diff files a.txt b.txt -f json  # JSON output
+```
+
+**Options:**
+- `--format, -f <format>` - Output format: `unified` (default), `json`
+- `--context, -c <n>` - Number of context lines (default: 3)
+
+### `diff dirs <dir1> <dir2>`
+
+Compare two directories and list differences.
+
+```bash
+diff dirs src/ dist/
+diff dirs v1/ v2/ -r        # Recursive
+diff dirs a/ b/ -f json     # JSON output
+```
+
+**Options:**
+- `--recursive, -r` - Compare subdirectories
+- `--content` - Show content diff for changed files
+- `--format, -f <format>` - Output format: `summary` (default), `json`
+
+### `diff text <text1> <text2>`
+
+Compare two text strings.
+
+```bash
+diff text "hello world" "hello there"
+```
+
+**Options:**
+- `--format, -f <format>` - Output format: `unified` (default), `json`
+- `--context, -c <n>` - Number of context lines (default: 3)
+
+### `diff json <json1> <json2>`
+
+Compare two JSON objects and show structural differences.
+
+```bash
+diff json '{"a":1}' '{"a":2}'
+diff json '{"users":[]}' '{"users":[{"id":1}]}'
+```
+
+**Options:**
+- `--format, -f <format>` - Output format: `summary` (default), `json`
+
+### `diff lines <text1> <text2>`
+
+Compare two sets of lines (ignoring order).
+
+```bash
+diff lines "a\nb\nc" "b\nc\nd"
+```
+
+**Options:**
+- `--ignore-empty` - Ignore empty lines
+- `--format, -f <format>` - Output format: `summary` (default), `json`
+
+## Output Formats
+
+### Unified Format
+
+Standard diff output with context lines:
+
+```
+--- file1.txt
++++ file2.txt
+
+@@ -1,3 +1,3 @@
+  line 1
+- line 2
++ new line 2
+  line 3
+
+2 additions, 1 deletions, 2 unchanged
+```
+
+### JSON Format
+
+Structured JSON output for programmatic use:
+
+```json
+{
+  "file1": "old.txt",
+  "file2": "new.txt",
+  "stats": {
+    "added": 2,
+    "removed": 1,
+    "unchanged": 5
+  },
+  "diff": [...]
+}
+```
+
+## Configuration
+
+Configure via environment variables:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `DIFF_MAX_FILE_SIZE` | `10485760` | Maximum file size to compare (bytes) |
+| `DIFF_CONTEXT_LINES` | `3` | Default context lines |
+
+Tool config in `tool.json`:
+
+```json
+{
+  "maxFileSize": 10485760,
+  "contextLines": 3,
+  "allowedPaths": [],
+  "deniedPaths": []
+}
+```
+
+## Security
+
+- **Path restrictions**: Use `allowedPaths` and `deniedPaths` to restrict file access
+- **Size limits**: Large files are rejected to prevent memory issues
+- **No shell execution**: Pure TypeScript implementation
+
+## Algorithm
+
+Uses the Longest Common Subsequence (LCS) algorithm for accurate line-by-line diffing.
+
+## Examples
+
+### Compare code files
+
+```bash
+diff files src/index.ts dist/index.ts
+```
+
+### Compare package versions
+
+```bash
+diff json "$(cat package-lock.v1.json)" "$(cat package-lock.v2.json)"
+```
+
+### Find changed files between directories
+
+```bash
+diff dirs build/ dist/ -r
+```
+
+### Check if configs differ
+
+```bash
+diff files config.local.json config.prod.json
+```

--- a/tools/diff/SKILL.md
+++ b/tools/diff/SKILL.md
@@ -1,0 +1,85 @@
+# Diff Tool Usage Guide
+
+Compare files and directories to find differences.
+
+## Quick Reference
+
+| Command | Purpose |
+|---------|---------|
+| `diff files <a> <b>` | Compare two files |
+| `diff dirs <a> <b>` | Compare two directories |
+| `diff text <a> <b>` | Compare text strings |
+| `diff json <a> <b>` | Compare JSON objects |
+| `diff lines <a> <b>` | Compare line sets (unordered) |
+
+## Common Tasks
+
+### Compare Two Files
+
+```bash
+diff files old.txt new.txt
+```
+
+Output shows:
+- `+` lines added
+- `-` lines removed
+- ` ` lines unchanged
+
+### Compare Directories
+
+```bash
+# Basic comparison
+diff dirs src/ dist/
+
+# Include subdirectories
+diff dirs v1/ v2/ -r
+
+# JSON output for parsing
+diff dirs a/ b/ -f json
+```
+
+### Compare JSON Objects
+
+```bash
+# Find what changed between configs
+diff json '{"debug":false}' '{"debug":true}'
+```
+
+Output shows path-based differences:
+- `~ path.to.key: old -> new` (value changed)
+- `+ path.to.key: value` (key added)
+- `- path.to.key: value` (key removed)
+
+### Compare Line Sets
+
+When order doesn't matter:
+
+```bash
+diff lines "a\nb\nc" "b\nc\nd"
+```
+
+Shows lines only in first, only in second, and common.
+
+## Options
+
+| Option | Description |
+|--------|-------------|
+| `-f, --format <fmt>` | Output format: `unified`, `summary`, `json` |
+| `-c, --context <n>` | Context lines around changes |
+| `-r, --recursive` | Compare subdirectories |
+
+## Examples
+
+```bash
+# Code review helper
+diff files src/old.ts src/new.ts -c 10
+
+# Check if files are identical
+diff files a.txt b.txt | grep "0 additions"
+
+# Find new/removed files
+diff dirs old-release/ new-release/ -r
+
+# Compare API responses
+diff json "$response1" "$response2"
+```

--- a/tools/diff/__tests__/unit.test.ts
+++ b/tools/diff/__tests__/unit.test.ts
@@ -1,0 +1,301 @@
+import { assertEquals, assertMatch } from "jsr:@std/assert";
+import { diffTool, diffLines, formatDiff, countDiffStats } from "../index.ts";
+
+const config = { maxFileSize: 10485760, contextLines: 3 };
+
+// Helper for async rejection testing
+async function expectReject(promise: Promise<unknown>): Promise<void> {
+  try {
+    await promise;
+    throw new Error("Expected promise to reject, but it resolved");
+  } catch {
+    // Expected
+  }
+}
+
+// ============ HELP TESTS ============
+Deno.test("help - shows help with no args", async () => {
+  const result = await diffTool([], config);
+  assertMatch(result, /Diff Tool/);
+  assertMatch(result, /COMMANDS/);
+});
+
+Deno.test("help - shows help with --help", async () => {
+  const result = await diffTool(["--help"], config);
+  assertMatch(result, /Diff Tool/);
+});
+
+// ============ DIFF LINES ALGORITHM TESTS ============
+Deno.test("diffLines - identical content", () => {
+  const diff = diffLines(["a", "b", "c"], ["a", "b", "c"]);
+  assertEquals(diff.length, 3);
+  assertEquals(diff.every(d => d.type === "unchanged"), true);
+});
+
+Deno.test("diffLines - single addition", () => {
+  const diff = diffLines(["a"], ["a", "b"]);
+  assertEquals(diff.length, 2);
+  assertEquals(diff[0].type, "unchanged");
+  assertEquals(diff[1].type, "added");
+  assertEquals(diff[1].content, "b");
+});
+
+Deno.test("diffLines - single removal", () => {
+  const diff = diffLines(["a", "b"], ["a"]);
+  assertEquals(diff.length, 2);
+  assertEquals(diff[0].type, "unchanged");
+  assertEquals(diff[1].type, "removed");
+  assertEquals(diff[1].content, "b");
+});
+
+Deno.test("diffLines - middle change", () => {
+  const diff = diffLines(["a", "b", "c"], ["a", "x", "c"]);
+  // LCS finds a and c unchanged, b removed, x added = 4 items
+  assertEquals(diff.length, 4);
+  assertEquals(diff[0].type, "unchanged");
+  // The removed and added can be in different orders depending on LCS backtrack
+  const removed = diff.find(d => d.type === "removed");
+  const added = diff.find(d => d.type === "added");
+  assertEquals(removed?.content, "b");
+  assertEquals(added?.content, "x");
+});
+
+Deno.test("diffLines - complete change", () => {
+  const diff = diffLines(["a", "b"], ["x", "y"]);
+  assertEquals(diff.length, 4);
+  assertEquals(diff.filter(d => d.type === "removed").length, 2);
+  assertEquals(diff.filter(d => d.type === "added").length, 2);
+});
+
+// ============ COUNT STATS TESTS ============
+Deno.test("countDiffStats - counts additions", () => {
+  const diff = diffLines(["a"], ["a", "b", "c"]);
+  const stats = countDiffStats(diff);
+  assertEquals(stats.added, 2);
+  assertEquals(stats.removed, 0);
+  assertEquals(stats.unchanged, 1);
+});
+
+Deno.test("countDiffStats - counts removals", () => {
+  const diff = diffLines(["a", "b", "c"], ["a"]);
+  const stats = countDiffStats(diff);
+  assertEquals(stats.added, 0);
+  assertEquals(stats.removed, 2);
+  assertEquals(stats.unchanged, 1);
+});
+
+Deno.test("countDiffStats - counts mixed", () => {
+  const diff = diffLines(["a", "b", "c"], ["a", "x", "y"]);
+  const stats = countDiffStats(diff);
+  assertEquals(stats.added, 2);
+  assertEquals(stats.removed, 2);
+  assertEquals(stats.unchanged, 1);
+});
+
+// ============ TEXT COMMAND TESTS ============
+Deno.test("text - identical text", async () => {
+  const result = await diffTool(["text", "hello", "hello"], config);
+  assertMatch(result, /0 additions/);
+  assertMatch(result, /0 deletions/);
+});
+
+Deno.test("text - with differences", async () => {
+  const result = await diffTool(["text", "hello world", "hello there"], config);
+  assertMatch(result, /\+ hello there/);
+  assertMatch(result, /- hello world/);
+});
+
+Deno.test("text - JSON format", async () => {
+  const result = await diffTool(["text", "a", "b", "-f", "json"], config);
+  const parsed = JSON.parse(result);
+  assertEquals(parsed.stats.added, 1);
+  assertEquals(parsed.stats.removed, 1);
+});
+
+// ============ JSON COMMAND TESTS ============
+Deno.test("json - identical objects", async () => {
+  const result = await diffTool(["json", '{"a":1}', '{"a":1}'], config);
+  assertEquals(result, "JSON objects are equal");
+});
+
+Deno.test("json - different values", async () => {
+  const result = await diffTool(["json", '{"a":1}', '{"a":2}'], config);
+  assertMatch(result, /~/);  // changed marker
+  assertMatch(result, /1.*2/);
+});
+
+Deno.test("json - added key", async () => {
+  const result = await diffTool(["json", '{"a":1}', '{"a":1,"b":2}'], config);
+  assertMatch(result, /\+/);  // added marker
+  assertMatch(result, /b/);
+});
+
+Deno.test("json - removed key", async () => {
+  const result = await diffTool(["json", '{"a":1,"b":2}', '{"a":1}'], config);
+  assertMatch(result, /-/);  // removed marker
+  assertMatch(result, /b/);
+});
+
+Deno.test("json - nested difference", async () => {
+  const result = await diffTool(
+    ["json", '{"outer":{"inner":1}}', '{"outer":{"inner":2}}'],
+    config
+  );
+  assertMatch(result, /outer\.inner/);
+});
+
+Deno.test("json - array difference", async () => {
+  const result = await diffTool(
+    ["json", '[1,2,3]', '[1,2,4]'],
+    config
+  );
+  assertMatch(result, /\[2\]/);
+});
+
+Deno.test("json - JSON format output", async () => {
+  const result = await diffTool(["json", '{"a":1}', '{"a":2}', "-f", "json"], config);
+  const parsed = JSON.parse(result);
+  assertEquals(parsed.equal, false);
+  assertEquals(parsed.differences.length, 1);
+});
+
+Deno.test("json - invalid JSON throws", () => {
+  return expectReject(diffTool(["json", "not json", "{}"], config));
+});
+
+// ============ LINES COMMAND TESTS ============
+Deno.test("lines - identical sets", async () => {
+  const result = await diffTool(["lines", "a\nb\nc", "c\nb\na"], config);
+  assertMatch(result, /Common: 3/);
+});
+
+Deno.test("lines - different sets", async () => {
+  const result = await diffTool(["lines", "a\nb\nc", "b\nc\nd"], config);
+  assertMatch(result, /Only in first/);
+  assertMatch(result, /Only in second/);
+});
+
+Deno.test("lines - JSON format", async () => {
+  const result = await diffTool(["lines", "a\nb", "b\nc", "-f", "json"], config);
+  const parsed = JSON.parse(result);
+  assertEquals(parsed.stats.onlyInFirst, 1);
+  assertEquals(parsed.stats.onlyInSecond, 1);
+  assertEquals(parsed.stats.common, 1);
+});
+
+// ============ FILES COMMAND TESTS ============
+Deno.test("files - requires two files", () => {
+  return expectReject(diffTool(["files", "one"], config));
+});
+
+// ============ DIRS COMMAND TESTS ============
+Deno.test("dirs - requires two directories", () => {
+  return expectReject(diffTool(["dirs", "one"], config));
+});
+
+// ============ ERROR HANDLING TESTS ============
+Deno.test("text - requires two arguments", () => {
+  return expectReject(diffTool(["text", "one"], config));
+});
+
+Deno.test("json - requires two arguments", () => {
+  return expectReject(diffTool(["json", "{}"], config));
+});
+
+Deno.test("lines - requires two arguments", () => {
+  return expectReject(diffTool(["lines", "a"], config));
+});
+
+Deno.test("unknown command throws", () => {
+  return expectReject(diffTool(["unknown"], config));
+});
+
+// ============ FORMAT DIFF TESTS ============
+Deno.test("formatDiff - includes context lines", () => {
+  const diff = diffLines(
+    ["1", "2", "3", "4", "5", "6", "7"],
+    ["1", "2", "3", "X", "5", "6", "7"]
+  );
+  const formatted = formatDiff(diff, 2, true);
+  assertMatch(formatted, /@@/);
+});
+
+// ============ ACTUAL FILE COMPARISON TESTS ============
+Deno.test("files - compare actual files", async () => {
+  // Create temp files
+  const file1 = "/tmp/diff_test_1.txt";
+  const file2 = "/tmp/diff_test_2.txt";
+  
+  await Deno.writeTextFile(file1, "hello\nworld");
+  await Deno.writeTextFile(file2, "hello\nthere");
+  
+  try {
+    const result = await diffTool(["files", file1, file2], config);
+    assertMatch(result, /world/);
+    assertMatch(result, /there/);
+  } finally {
+    await Deno.remove(file1);
+    await Deno.remove(file2);
+  }
+});
+
+Deno.test("files - identical files", async () => {
+  const file1 = "/tmp/diff_same_1.txt";
+  const file2 = "/tmp/diff_same_2.txt";
+  
+  await Deno.writeTextFile(file1, "same content");
+  await Deno.writeTextFile(file2, "same content");
+  
+  try {
+    const result = await diffTool(["files", file1, file2], config);
+    assertMatch(result, /0 additions/);
+    assertMatch(result, /0 deletions/);
+  } finally {
+    await Deno.remove(file1);
+    await Deno.remove(file2);
+  }
+});
+
+// ============ DIRECTORY COMPARISON TESTS ============
+Deno.test("dirs - compare directories", async () => {
+  const dir1 = "/tmp/diff_dir1";
+  const dir2 = "/tmp/diff_dir2";
+  
+  await Deno.mkdir(dir1, { recursive: true });
+  await Deno.mkdir(dir2, { recursive: true });
+  
+  await Deno.writeTextFile(`${dir1}/same.txt`, "same");
+  await Deno.writeTextFile(`${dir2}/same.txt`, "same");
+  await Deno.writeTextFile(`${dir1}/only1.txt`, "only in dir1");
+  await Deno.writeTextFile(`${dir2}/only2.txt`, "only in dir2");
+  
+  try {
+    const result = await diffTool(["dirs", dir1, dir2], config);
+    assertMatch(result, /only1.txt/);
+    assertMatch(result, /only2.txt/);
+  } finally {
+    await Deno.remove(dir1, { recursive: true });
+    await Deno.remove(dir2, { recursive: true });
+  }
+});
+
+Deno.test("dirs - JSON format", async () => {
+  const dir1 = "/tmp/diff_json_dir1";
+  const dir2 = "/tmp/diff_json_dir2";
+  
+  await Deno.mkdir(dir1, { recursive: true });
+  await Deno.mkdir(dir2, { recursive: true });
+  
+  await Deno.writeTextFile(`${dir1}/a.txt`, "a");
+  await Deno.writeTextFile(`${dir2}/b.txt`, "b");
+  
+  try {
+    const result = await diffTool(["dirs", dir1, dir2, "-f", "json"], config);
+    const parsed = JSON.parse(result);
+    assertEquals(parsed.onlyInDir1.includes("a.txt"), true);
+    assertEquals(parsed.onlyInDir2.includes("b.txt"), true);
+  } finally {
+    await Deno.remove(dir1, { recursive: true });
+    await Deno.remove(dir2, { recursive: true });
+  }
+});

--- a/tools/diff/deno.lock
+++ b/tools/diff/deno.lock
@@ -1,0 +1,18 @@
+{
+  "version": "4",
+  "specifiers": {
+    "jsr:@std/assert@*": "1.0.19",
+    "jsr:@std/internal@^1.0.12": "1.0.12"
+  },
+  "jsr": {
+    "@std/assert@1.0.19": {
+      "integrity": "eaada96ee120cb980bc47e040f82814d786fe8162ecc53c91d8df60b8755991e",
+      "dependencies": [
+        "jsr:@std/internal"
+      ]
+    },
+    "@std/internal@1.0.12": {
+      "integrity": "972a634fd5bc34b242024402972cd5143eac68d8dffaca5eaa4dba30ce17b027"
+    }
+  }
+}

--- a/tools/diff/index.ts
+++ b/tools/diff/index.ts
@@ -1,0 +1,691 @@
+#!/usr/bin/env bun
+/**
+ * Diff Tool - Compare files and directories
+ *
+ * Provides commands for:
+ * - files: Compare two files
+ * - dirs: Compare two directories
+ * - text: Compare two text strings
+ * - json: Compare two JSON objects
+ * - lines: Compare two sets of lines
+ */
+
+interface DiffConfig {
+  maxFileSize?: number;
+  contextLines?: number;
+  allowedPaths?: string[];
+  deniedPaths?: string[];
+}
+
+const DEFAULT_MAX_FILE_SIZE = 10 * 1024 * 1024; // 10 MB
+const DEFAULT_CONTEXT_LINES = 3;
+
+function parseArgs(args: string[]): {
+  command: string;
+  options: Record<string, string | boolean>;
+  positional: string[];
+} {
+  const options: Record<string, string | boolean> = {};
+  const positional: string[] = [];
+  let command = "";
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg.startsWith("--")) {
+      const key = arg.slice(2);
+      if (i + 1 < args.length && !args[i + 1].startsWith("-")) {
+        options[key] = args[++i];
+      } else {
+        options[key] = true;
+      }
+    } else if (arg.startsWith("-") && arg.length === 2) {
+      const key = arg.slice(1);
+      if (i + 1 < args.length && !args[i + 1].startsWith("-")) {
+        options[key] = args[++i];
+      } else {
+        options[key] = true;
+      }
+    } else if (!command) {
+      command = arg;
+    } else {
+      positional.push(arg);
+    }
+  }
+
+  return { command, options, positional };
+}
+
+// Security check for paths
+function checkPath(path: string, config: DiffConfig): void {
+  const allowed = config.allowedPaths;
+  const denied = config.deniedPaths;
+
+  if (denied && denied.length > 0) {
+    for (const d of denied) {
+      if (path.startsWith(d)) {
+        throw new Error(`Path is denied: ${path}`);
+      }
+    }
+  }
+
+  if (allowed && allowed.length > 0) {
+    let isAllowed = false;
+    for (const a of allowed) {
+      if (path.startsWith(a)) {
+        isAllowed = true;
+        break;
+      }
+    }
+    if (!isAllowed) {
+      throw new Error(`Path is not in allowed list: ${path}`);
+    }
+  }
+}
+
+// Read file with size check
+async function readFile(path: string, config: DiffConfig): Promise<string> {
+  checkPath(path, config);
+  
+  const stat = await Deno.stat(path);
+  const maxSize = config.maxFileSize || DEFAULT_MAX_FILE_SIZE;
+  
+  if (stat.size > maxSize) {
+    throw new Error(`File too large: ${path} (${stat.size} bytes, max: ${maxSize})`);
+  }
+  
+  return await Deno.readTextFile(path);
+}
+
+// Diff algorithm (Longest Common Subsequence based)
+interface DiffLine {
+  type: "added" | "removed" | "unchanged";
+  content: string;
+  oldLine?: number;
+  newLine?: number;
+}
+
+function diffLines(oldLines: string[], newLines: string[]): DiffLine[] {
+  // Build LCS table
+  const m = oldLines.length;
+  const n = newLines.length;
+  const dp: number[][] = Array(m + 1).fill(null).map(() => Array(n + 1).fill(0));
+
+  for (let i = 1; i <= m; i++) {
+    for (let j = 1; j <= n; j++) {
+      if (oldLines[i - 1] === newLines[j - 1]) {
+        dp[i][j] = dp[i - 1][j - 1] + 1;
+      } else {
+        dp[i][j] = Math.max(dp[i - 1][j], dp[i][j - 1]);
+      }
+    }
+  }
+
+  // Backtrack to find diff
+  const result: DiffLine[] = [];
+  let i = m, j = n;
+
+  while (i > 0 || j > 0) {
+    if (i > 0 && j > 0 && oldLines[i - 1] === newLines[j - 1]) {
+      result.unshift({
+        type: "unchanged",
+        content: oldLines[i - 1],
+        oldLine: i,
+        newLine: j,
+      });
+      i--;
+      j--;
+    } else if (j > 0 && (i === 0 || dp[i][j - 1] >= dp[i - 1][j])) {
+      result.unshift({
+        type: "added",
+        content: newLines[j - 1],
+        newLine: j,
+      });
+      j--;
+    } else if (i > 0) {
+      result.unshift({
+        type: "removed",
+        content: oldLines[i - 1],
+        oldLine: i,
+      });
+      i--;
+    }
+  }
+
+  return result;
+}
+
+// Format diff output
+function formatDiff(diff: DiffLine[], contextLines: number, unified: boolean): string {
+  const output: string[] = [];
+  let i = 0;
+
+  while (i < diff.length) {
+    // Find next change block
+    if (diff[i].type === "unchanged") {
+      i++;
+      continue;
+    }
+
+    // Find the extent of the change block
+    let start = Math.max(0, i - contextLines);
+    let end = i;
+    while (end < diff.length && diff[end].type !== "unchanged") {
+      end++;
+    }
+    end = Math.min(diff.length, end + contextLines);
+
+    // Output header
+    if (unified) {
+      const oldStart = diff[start].oldLine || 1;
+      const newStart = diff[start].newLine || 1;
+      const oldCount = end - start;
+      const newCount = end - start;
+      output.push(`@@ -${oldStart},${oldCount} +${newStart},${newCount} @@`);
+    }
+
+    // Output lines
+    for (let j = start; j < end; j++) {
+      const line = diff[j];
+      switch (line.type) {
+        case "added":
+          output.push(`+ ${line.content}`);
+          break;
+        case "removed":
+          output.push(`- ${line.content}`);
+          break;
+        case "unchanged":
+          output.push(`  ${line.content}`);
+          break;
+      }
+    }
+
+    output.push("");
+    i = end;
+  }
+
+  return output.join("\n");
+}
+
+// Count diff statistics
+function countDiffStats(diff: DiffLine[]): { added: number; removed: number; unchanged: number } {
+  let added = 0, removed = 0, unchanged = 0;
+  for (const line of diff) {
+    switch (line.type) {
+      case "added": added++; break;
+      case "removed": removed++; break;
+      case "unchanged": unchanged++; break;
+    }
+  }
+  return { added, removed, unchanged };
+}
+
+// Compare files
+async function cmdFiles(
+  file1: string,
+  file2: string,
+  options: Record<string, string | boolean>,
+  config: DiffConfig
+): Promise<string> {
+  const content1 = await readFile(file1, config);
+  const content2 = await readFile(file2, config);
+
+  const lines1 = content1.split("\n");
+  const lines2 = content2.split("\n");
+
+  const diff = diffLines(lines1, lines2);
+  const stats = countDiffStats(diff);
+
+  const format = String(options.format || options.f || "unified");
+  const contextLines = Number(options.context || options.c || config.contextLines || DEFAULT_CONTEXT_LINES);
+
+  if (format === "json") {
+    return JSON.stringify({
+      file1,
+      file2,
+      stats,
+      diff: diff,
+    }, null, 2);
+  }
+
+  const output: string[] = [];
+  output.push(`--- ${file1}`);
+  output.push(`+++ ${file2}`);
+  output.push("");
+  output.push(formatDiff(diff, contextLines, format === "unified"));
+  output.push("");
+  output.push(`${stats.added} additions, ${stats.removed} deletions, ${stats.unchanged} unchanged`);
+
+  return output.join("\n");
+}
+
+// Compare directories
+async function cmdDirs(
+  dir1: string,
+  dir2: string,
+  options: Record<string, string | boolean>,
+  config: DiffConfig
+): Promise<string> {
+  checkPath(dir1, config);
+  checkPath(dir2, config);
+
+  const recursive = options.recursive || options.r;
+  const showContent = options.content;
+
+  // Get files in both directories
+  async function getFiles(dir: string, base: string = ""): Promise<string[]> {
+    const files: string[] = [];
+    try {
+      for await (const entry of Deno.readDir(dir)) {
+        const path = `${dir}/${entry.name}`;
+        const relPath = base ? `${base}/${entry.name}` : entry.name;
+        
+        if (entry.isFile) {
+          files.push(relPath);
+        } else if (entry.isDirectory && recursive) {
+          files.push(...await getFiles(path, relPath));
+        }
+      }
+    } catch {
+      // Directory doesn't exist or can't be read
+    }
+    return files;
+  }
+
+  const [files1, files2] = await Promise.all([
+    getFiles(dir1),
+    getFiles(dir2),
+  ]);
+
+  const set1 = new Set(files1);
+  const set2 = new Set(files2);
+
+  const onlyIn1 = files1.filter(f => !set2.has(f)).sort();
+  const onlyIn2 = files2.filter(f => !set1.has(f)).sort();
+  const common = files1.filter(f => set2.has(f)).sort();
+
+  // Compare common files
+  const changed: { file: string; added: number; removed: number }[] = [];
+  const unchanged: string[] = [];
+
+  for (const file of common) {
+    try {
+      const content1 = await readFile(`${dir1}/${file}`, config);
+      const content2 = await readFile(`${dir2}/${file}`, config);
+      
+      if (content1 === content2) {
+        unchanged.push(file);
+      } else {
+        const diff = diffLines(content1.split("\n"), content2.split("\n"));
+        const stats = countDiffStats(diff);
+        changed.push({ file, added: stats.added, removed: stats.removed });
+      }
+    } catch {
+      // Can't compare binary or unreadable files
+      unchanged.push(file);
+    }
+  }
+
+  const format = String(options.format || options.f || "summary");
+
+  if (format === "json") {
+    return JSON.stringify({
+      dir1,
+      dir2,
+      onlyInDir1: onlyIn1,
+      onlyInDir2: onlyIn2,
+      changed,
+      unchanged,
+      stats: {
+        added: onlyIn2.length,
+        removed: onlyIn1.length,
+        changed: changed.length,
+        unchanged: unchanged.length,
+      },
+    }, null, 2);
+  }
+
+  const output: string[] = [];
+  
+  output.push(`Comparing directories:`);
+  output.push(`  ${dir1}`);
+  output.push(`  ${dir2}`);
+  output.push("");
+
+  if (onlyIn1.length > 0) {
+    output.push(`Only in ${dir1}:`);
+    for (const f of onlyIn1) {
+      output.push(`  - ${f}`);
+    }
+    output.push("");
+  }
+
+  if (onlyIn2.length > 0) {
+    output.push(`Only in ${dir2}:`);
+    for (const f of onlyIn2) {
+      output.push(`  + ${f}`);
+    }
+    output.push("");
+  }
+
+  if (changed.length > 0) {
+    output.push("Changed files:");
+    for (const c of changed) {
+      output.push(`  ~ ${c.file} (+${c.added}/-${c.removed})`);
+    }
+    output.push("");
+  }
+
+  output.push(`Summary: ${onlyIn1.length} removed, ${onlyIn2.length} added, ${changed.length} changed, ${unchanged.length} unchanged`);
+
+  return output.join("\n");
+}
+
+// Compare text strings
+function cmdText(
+  text1: string,
+  text2: string,
+  options: Record<string, string | boolean>,
+  config: DiffConfig
+): string {
+  const lines1 = text1.split("\n");
+  const lines2 = text2.split("\n");
+
+  const diff = diffLines(lines1, lines2);
+  const stats = countDiffStats(diff);
+
+  const format = String(options.format || options.f || "unified");
+  const contextLines = Number(options.context || options.c || config.contextLines || DEFAULT_CONTEXT_LINES);
+
+  if (format === "json") {
+    return JSON.stringify({
+      stats,
+      diff,
+    }, null, 2);
+  }
+
+  const output: string[] = [];
+  output.push("--- text1");
+  output.push("+++ text2");
+  output.push("");
+  output.push(formatDiff(diff, contextLines, format === "unified"));
+  output.push("");
+  output.push(`${stats.added} additions, ${stats.removed} deletions, ${stats.unchanged} unchanged`);
+
+  return output.join("\n");
+}
+
+// Compare JSON objects
+function cmdJson(
+  json1: string,
+  json2: string,
+  options: Record<string, string | boolean>,
+  config: DiffConfig
+): string {
+  let obj1: unknown, obj2: unknown;
+  
+  try {
+    obj1 = JSON.parse(json1);
+  } catch (e) {
+    throw new Error(`Invalid JSON in first argument: ${(e as Error).message}`);
+  }
+  
+  try {
+    obj2 = JSON.parse(json2);
+  } catch (e) {
+    throw new Error(`Invalid JSON in second argument: ${(e as Error).message}`);
+  }
+
+  const format = String(options.format || options.f || "summary");
+
+  // Deep comparison
+  function deepCompare(a: unknown, b: unknown, path: string = ""): { type: string; path: string; details?: string }[] {
+    const result: { type: string; path: string; details?: string }[] = [];
+
+    if (typeof a !== typeof b) {
+      result.push({ type: "type-change", path, details: `${typeof a} -> ${typeof b}` });
+      return result;
+    }
+
+    if (a === null || b === null) {
+      if (a !== b) {
+        result.push({ type: "value-change", path, details: `${a} -> ${b}` });
+      }
+      return result;
+    }
+
+    if (typeof a !== "object") {
+      if (a !== b) {
+        result.push({ type: "value-change", path, details: `${JSON.stringify(a)} -> ${JSON.stringify(b)}` });
+      }
+      return result;
+    }
+
+    if (Array.isArray(a) !== Array.isArray(b)) {
+      result.push({ type: "type-change", path, details: Array.isArray(a) ? "array -> object" : "object -> array" });
+      return result;
+    }
+
+    if (Array.isArray(a) && Array.isArray(b)) {
+      const maxLen = Math.max(a.length, b.length);
+      for (let i = 0; i < maxLen; i++) {
+        const newPath = `${path}[${i}]`;
+        if (i >= a.length) {
+          result.push({ type: "added", path: newPath, details: JSON.stringify(b[i]) });
+        } else if (i >= b.length) {
+          result.push({ type: "removed", path: newPath, details: JSON.stringify(a[i]) });
+        } else {
+          result.push(...deepCompare(a[i], b[i], newPath));
+        }
+      }
+      return result;
+    }
+
+    // Both are objects
+    const keys1 = Object.keys(a as Record<string, unknown>);
+    const keys2 = Object.keys(b as Record<string, unknown>);
+    const allKeys = new Set([...keys1, ...keys2]);
+
+    for (const key of allKeys) {
+      const newPath = path ? `${path}.${key}` : key;
+      const objA = a as Record<string, unknown>;
+      const objB = b as Record<string, unknown>;
+      
+      if (!(key in objA)) {
+        result.push({ type: "added", path: newPath, details: JSON.stringify(objB[key]) });
+      } else if (!(key in objB)) {
+        result.push({ type: "removed", path: newPath, details: JSON.stringify(objA[key]) });
+      } else {
+        result.push(...deepCompare(objA[key], objB[key], newPath));
+      }
+    }
+
+    return result;
+  }
+
+  const differences = deepCompare(obj1, obj2);
+
+  if (format === "json") {
+    return JSON.stringify({
+      equal: differences.length === 0,
+      differences,
+    }, null, 2);
+  }
+
+  if (differences.length === 0) {
+    return "JSON objects are equal";
+  }
+
+  const output: string[] = [];
+  output.push(`Found ${differences.length} differences:`);
+  output.push("");
+
+  for (const diff of differences) {
+    const icon = diff.type === "added" ? "+" : diff.type === "removed" ? "-" : "~";
+    output.push(`  ${icon} ${diff.path}: ${diff.details || diff.type}`);
+  }
+
+  return output.join("\n");
+}
+
+// Compare line sets (ignoring order)
+function cmdLines(
+  text1: string,
+  text2: string,
+  options: Record<string, string | boolean>,
+  config: DiffConfig
+): string {
+  const lines1 = text1.split("\n").filter(l => l.trim() || !options["ignore-empty"]);
+  const lines2 = text2.split("\n").filter(l => l.trim() || !options["ignore-empty"]);
+
+  const set1 = new Set(lines1);
+  const set2 = new Set(lines2);
+
+  const onlyIn1 = lines1.filter(l => !set2.has(l));
+  const onlyIn2 = lines2.filter(l => !set1.has(l));
+  const common = lines1.filter(l => set2.has(l));
+
+  const format = String(options.format || options.f || "summary");
+
+  if (format === "json") {
+    return JSON.stringify({
+      onlyInFirst: onlyIn1,
+      onlyInSecond: onlyIn2,
+      common,
+      stats: {
+        onlyInFirst: onlyIn1.length,
+        onlyInSecond: onlyIn2.length,
+        common: common.length,
+      },
+    }, null, 2);
+  }
+
+  const output: string[] = [];
+  
+  output.push("Line set comparison:");
+  output.push("");
+
+  if (onlyIn1.length > 0) {
+    output.push(`Only in first (${onlyIn1.length}):`);
+    for (const l of onlyIn1) {
+      output.push(`  - ${l}`);
+    }
+    output.push("");
+  }
+
+  if (onlyIn2.length > 0) {
+    output.push(`Only in second (${onlyIn2.length}):`);
+    for (const l of onlyIn2) {
+      output.push(`  + ${l}`);
+    }
+    output.push("");
+  }
+
+  output.push(`Common: ${common.length} lines`);
+
+  return output.join("\n");
+}
+
+function showHelp(): string {
+  return `
+Diff Tool - Compare files and directories
+
+USAGE:
+  diff <command> [options] [arguments]
+
+COMMANDS:
+  files <file1> <file2>    Compare two files
+    --format, -f <format>  Output format: unified, json
+    --context, -c <n>      Context lines (default: 3)
+
+  dirs <dir1> <dir2>       Compare two directories
+    --recursive, -r        Compare subdirectories
+    --content              Show content diff for changed files
+    --format, -f <format>  Output format: summary, json
+
+  text <text1> <text2>     Compare two text strings
+    --format, -f <format>  Output format: unified, json
+    --context, -c <n>      Context lines (default: 3)
+
+  json <json1> <json2>     Compare two JSON objects
+    --format, -f <format>  Output format: summary, json
+
+  lines <text1> <text2>    Compare two sets of lines (ignoring order)
+    --ignore-empty         Ignore empty lines
+    --format, -f <format>  Output format: summary, json
+
+EXAMPLES:
+  diff files old.txt new.txt
+  diff files file1.ts file2.ts -c 5
+  diff dirs src/ dist/ -r
+  diff text "hello world" "hello there"
+  diff json '{"a":1}' '{"a":2}'
+  diff lines "a\\nb\\nc" "b\\nc\\nd"
+`;
+}
+
+async function main(args: string[], config: DiffConfig = {}): Promise<string> {
+  const { command, options, positional } = parseArgs(args);
+
+  switch (command) {
+    case "":
+    case "help":
+    case "--help":
+    case "-h":
+      return showHelp();
+
+    case "files":
+    case "file":
+      if (positional.length < 2) {
+        throw new Error("files requires two file paths");
+      }
+      return cmdFiles(positional[0], positional[1], options, config);
+
+    case "dirs":
+    case "dir":
+    case "directories":
+      if (positional.length < 2) {
+        throw new Error("dirs requires two directory paths");
+      }
+      return cmdDirs(positional[0], positional[1], options, config);
+
+    case "text":
+    case "string":
+      if (positional.length < 2) {
+        throw new Error("text requires two text strings");
+      }
+      return cmdText(positional[0], positional[1], options, config);
+
+    case "json":
+      if (positional.length < 2) {
+        throw new Error("json requires two JSON strings");
+      }
+      return cmdJson(positional[0], positional[1], options, config);
+
+    case "lines":
+      if (positional.length < 2) {
+        throw new Error("lines requires two text strings");
+      }
+      return cmdLines(positional[0], positional[1], options, config);
+
+    default:
+      throw new Error(`Unknown command: ${command}. Use --help for usage.`);
+  }
+}
+
+// Run if called directly
+if (import.meta.main) {
+  const args = Deno.args;
+  const config: DiffConfig = {
+    maxFileSize: parseInt(Deno.env.get("DIFF_MAX_FILE_SIZE") || "10485760"),
+    contextLines: parseInt(Deno.env.get("DIFF_CONTEXT_LINES") || "3"),
+  };
+
+  main(args, config)
+    .then((result) => console.log(result))
+    .catch((err) => {
+      console.error(`Error: ${err.message}`);
+      Deno.exit(1);
+    });
+}
+
+export { main as diffTool, diffLines, formatDiff, countDiffStats };

--- a/tools/diff/package.json
+++ b/tools/diff/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "diff",
+  "version": "1.0.0",
+  "description": "Compare files and directories to find differences",
+  "main": "index.ts",
+  "scripts": {
+    "test": "deno test __tests__/unit.test.ts --allow-all"
+  }
+}

--- a/tools/diff/tool.json
+++ b/tools/diff/tool.json
@@ -1,0 +1,39 @@
+{
+  "name": "diff",
+  "version": "1.0.0",
+  "description": "Compare files and directories to find differences",
+  "author": "beige-agent",
+  "main": "index.ts",
+  "commands": [
+    "files",
+    "dirs",
+    "text",
+    "json",
+    "lines"
+  ],
+  "config": {
+    "type": "object",
+    "properties": {
+      "maxFileSize": {
+        "type": "number",
+        "description": "Maximum file size to compare in bytes",
+        "default": 10485760
+      },
+      "contextLines": {
+        "type": "number",
+        "description": "Number of context lines to show around changes",
+        "default": 3
+      },
+      "allowedPaths": {
+        "type": "array",
+        "items": { "type": "string" },
+        "description": "List of allowed paths (empty = all allowed)"
+      },
+      "deniedPaths": {
+        "type": "array",
+        "items": { "type": "string" },
+        "description": "List of denied paths"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Diff Tool - Compare Files and Directories

Provides file and directory comparison functionality.

### Commands

| Command | Description |
|---------|-------------|
| `files` | Compare two files with unified diff output |
| `dirs` | Compare two directories |
| `text` | Compare two text strings |
| `json` | Compare two JSON objects |
| `lines` | Compare two sets of lines (ignoring order) |

### Features

- **LCS-based Diff Algorithm**: Accurate line-by-line comparison
- **Unified Diff Format**: Standard diff output with context lines
- **JSON Format**: Structured output for programmatic use
- **Directory Comparison**: Recursive comparison with change summary
- **JSON Deep Comparison**: Path-based structural differences
- **Line Set Comparison**: Order-independent comparison

### Output Formats

- `unified`: Standard diff with `+`/`-` prefixes and context
- `summary`: Human-readable summary
- `json`: Structured JSON for parsing

### Examples

```bash
# Compare files
diff files old.txt new.txt

# Compare directories recursively  
diff dirs src/ dist/ -r

# Compare JSON objects
diff json '{"a":1}' '{"a":2}'

# Compare text
diff text "hello world" "hello there"
```

### Testing

35 unit tests covering:
- LCS diff algorithm
- All commands
- Output formats
- Error handling
- File and directory operations